### PR TITLE
Add gh-issue-to-pr agent skill

### DIFF
--- a/.agent/skills/gh-issue-to-pr/SKILL.md
+++ b/.agent/skills/gh-issue-to-pr/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: gh-issue-to-pr
+description: >
+  Fetch a GitHub issue with gh, implement and add unit tests, run lint and typecheck
+  until clean (and Rust fmt/clippy when src-tauri changes), then open or update a PR
+  using the project pr skill. Use when the user gives an issue number or URL or asks to
+  implement an issue through to a pull request.
+compatibility: Requires gh CLI authenticated (gh auth status). Windows uses PowerShell.
+---
+
+# GitHub issue → implementation → PR
+
+## When to use
+
+- A GitHub issue number, URL, or explicit request to implement an issue and open a PR.
+- The user wants the full path: understand issue → code → tests → quality gate → PR.
+
+## Prerequisites
+
+- `gh` installed and logged in (`gh auth status`).
+- Prefer **PowerShell** on Windows for commands below.
+
+## Workflow
+
+### 1. Fetch and understand the issue
+
+```powershell
+gh issue view <N> --json number,title,body,state,labels,assignees,url
+```
+
+- If acceptance criteria are unclear, ask the user before coding.
+- Keep scope aligned with the issue; follow `AGENTS.md` (English for code and commits; PowerShell for shell examples).
+
+### 2. Implement
+
+- Match existing project patterns; keep changes minimal and focused on the issue.
+- If the change touches **Rust** under `src-tauri/`, include Rust formatting and clippy in the quality gate (step 4).
+
+### 3. Unit tests
+
+From the repository root:
+
+```powershell
+npm run test
+```
+
+- Add or update tests for new behavior. The project uses Vitest with the **unit** project (`vitest run --project=unit`).
+
+### 4. Lint, typecheck, and Rust (repeat until clean)
+
+**JavaScript / TypeScript / Svelte** (run for relevant changes; always before a PR):
+
+```powershell
+npm run lint
+npm run check
+```
+
+- Fix all reported issues and re-run until **no errors**. ESLint is required for changes per `AGENTS.md` (`npm run lint`).
+
+**Rust** (when `src-tauri/` or Rust sources change):
+
+```powershell
+npm run fmt:rust
+npm run lint:rust
+```
+
+- If the same failure persists after two fix attempts, stop and ask the user.
+
+### 5. Pull request
+
+Only after step 4 succeeds:
+
+1. Follow the project skill **`pr`** (`.agent/skills/pr/SKILL.md`): `git fetch origin`, review `git log` / `git diff` against the base branch, fill `.agent/skills/pr/references/PR_TEMPLATE.md`, then `gh pr create` or `gh pr edit`.
+2. Optional helper: `.\.agent\skills\pr\scripts\generate-pr-summary.ps1 -BaseBranch <base>`
+3. PR title and body in **English** unless the repository explicitly uses another language for PRs (`AGENTS.md`).
+
+## Security
+
+- Do not paste secrets, tokens, or `.env` contents into issues, commits, or PR text.
+
+## Further reading
+
+- Additional `gh issue` patterns and edge cases: `references/GH_ISSUE_WORKFLOW.md`.

--- a/.agent/skills/gh-issue-to-pr/references/GH_ISSUE_WORKFLOW.md
+++ b/.agent/skills/gh-issue-to-pr/references/GH_ISSUE_WORKFLOW.md
@@ -1,0 +1,34 @@
+# GitHub issue workflow (reference)
+
+Optional detail for `gh-issue-to-pr`. Load when listing issues, filtering, or debugging `gh`.
+
+## List issues
+
+```powershell
+gh issue list --limit 20
+gh issue list --label bug
+gh issue list --state open
+```
+
+## View issue (human-readable)
+
+```powershell
+gh issue view 42
+```
+
+## View issue (JSON for agents)
+
+```powershell
+gh issue view 42 --json number,title,body,state,labels,assignees,url,comments
+```
+
+## Open issue in browser
+
+```powershell
+gh issue view 42 --web
+```
+
+## Notes
+
+- Prefer `--json` when the agent must parse title/body without ambiguity.
+- If the issue references another issue or PR, follow links in the body or use `gh issue view` / `gh pr view` for those numbers.


### PR DESCRIPTION
# Add gh-issue-to-pr agent skill

## Summary

Adds a Cursor Agent skill at `.agent/skills/gh-issue-to-pr/` that documents an end-to-end workflow: fetch a GitHub issue with `gh`, implement the change, run unit tests, then run lint and typecheck (plus Rust `fmt`/`clippy` when `src-tauri/` is touched). After the quality gate passes, the agent follows the existing `.agent/skills/pr` skill to open or update a PR.

## Base branch

main

## Changes

- Add `SKILL.md` with numbered steps, project commands (`npm run test`, `npm run lint`, `npm run check`, `npm run fmt:rust`, `npm run lint:rust`), and pointers to `AGENTS.md` and the `pr` skill.
- Add `references/GH_ISSUE_WORKFLOW.md` with optional `gh issue list` / `gh issue view` examples for agents.

## How to test

1. Open Cursor Settings → Rules and confirm the skill is listed (or invoke `/gh-issue-to-pr` if using explicit skill commands).
2. `npm run lint`, `npm run check`, and `npm run test` pass on this branch (verified locally after `npm install`).

## Screenshots / recording

N/A — documentation-only change.

## Checklist

- [x] `npm run lint` passes (or note exception).
- [x] No secrets or env values in code or PR text.
- [x] Breaking changes documented if any (none).
