### PR TITLE
Add gh-issue-create Cursor skill for drafting GitHub issues

### DIFF
--- a/.cursor/skills/gh-issue-create/SKILL.md
+++ b/.cursor/skills/gh-issue-create/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: gh-issue-create
+description: >
+  Propose a GitHub issue title and body from the user's prompt; for frontend or UI work,
+  include an ASCII wireframe for screen layout. After explicit user approval, create the
+  issue with gh. Use when the user wants to draft or file a new issue from an idea or spec.
+compatibility: Requires gh CLI authenticated (gh auth status). Windows uses PowerShell.
+---
+
+# GitHub issue creation (draft → approve → create)
+
+## When to use
+
+- The user wants to turn a prompt or rough idea into a GitHub issue.
+- They want suggested title, body, and (for UI) an ASCII screen sketch before anything is filed.
+- They asked to create an issue after reviewing a draft.
+
+## Prerequisites
+
+- `gh` installed and logged in (`gh auth status`).
+- Prefer **PowerShell** on Windows for commands below.
+- Default target is the **current repository** (`gh repo view`). If the user names another repo, pass `-R owner/repo` to `gh issue create`.
+
+## Workflow
+
+### 1. Clarify (only if needed)
+
+If the prompt is missing essentials, ask briefly for:
+
+- Goal and audience
+- In scope / out of scope
+- Priority or deadline (optional)
+
+Do not block on perfection; infer reasonable defaults and state them in the draft.
+
+### 2. Propose title and body (do not create yet)
+
+- **Title**: Short, specific, actionable (imperative or “[area] one-line summary”). Avoid duplicates; prefer concrete nouns over “fix stuff”.
+- **Body** should usually include:
+  - **Context** — why this matters
+  - **What to do** — bullets or user story
+  - **Acceptance criteria** — checklist the implementer can verify
+  - **Notes** — dependencies, risks, or follow-ups (optional)
+
+Match the repository’s language for issue text if the user or `AGENTS.md` implies one language; otherwise default to **English** for consistency with `AGENTS.md`.
+
+**Frontend / UI-heavy work**: Add a **screen wireframe** using ASCII art in a fenced code block (plain ` ``` ` fence for monospace). Keep width around **80 columns**; split into multiple blocks if there are multiple screens. Use simple symbols (`+---+`, `[Save]`, `[_______]`). State that the sketch is a layout hint, not final design.
+
+Optional: suggest **labels** or milestones by name (only use them in `gh issue create` if they exist on the repo).
+
+### 3. Approval gate (required)
+
+**Do not run `gh issue create` until the user explicitly approves** (e.g. “create it”, “OK”, “yes”, “その内容で”, “issue を作成して”).
+
+If they want edits, revise the draft and ask again.
+
+### 4. Create the issue
+
+Write the final body to a UTF-8 file to avoid escaping issues, then:
+
+```powershell
+gh issue create --title "<title>" --body-file <path-to-body.md>
+```
+
+Useful flags:
+
+- `--label "name"` — repeat or comma-separate as supported by your `gh` version
+- `-R owner/repo` — another repository
+
+After success, share the issue URL or run `gh issue view <n> --web`.
+
+### 5. Relation to other skills
+
+- Implementation after filing: project skill **`gh-issue-to-pr`** (fetch issue → code → PR).
+- Pull requests: project skill **`pr`**.
+
+## Security
+
+- Do not paste secrets, tokens, or `.env` contents into issue titles or bodies.
+
+## Further reading
+
+- ASCII and body structure: `references/ISSUE_BODY_GUIDE.md`.

--- a/.cursor/skills/gh-issue-create/references/ISSUE_BODY_GUIDE.md
+++ b/.cursor/skills/gh-issue-create/references/ISSUE_BODY_GUIDE.md
@@ -1,0 +1,40 @@
+# Issue body and ASCII wireframes
+
+Use this reference when drafting issues under **`gh-issue-create`**. Keep the main `SKILL.md` short; load this file when the user needs detail or examples.
+
+## Body structure
+
+1. **Context** — Problem or opportunity in 1–3 sentences.
+2. **Proposal / scope** — Bullets or a short user story (“As a … I want … so that …”).
+3. **Acceptance criteria** — Checklist (`- [ ]`) that is testable.
+4. **Out of scope** (optional) — Prevents scope creep.
+5. **Wireframe** — Only for UI/frontend issues; see below.
+
+If the repo uses GitHub issue templates under `.github/ISSUE_TEMPLATE/`, align headings with the template the user intends to use. For `gh issue create --template`, check `gh issue create --help` for template support.
+
+## ASCII wireframe rules
+
+- **Purpose**: Communicate layout and major regions, not pixels or branding.
+- **Width**: Aim for ≤80 characters per line so the issue renders on narrow views.
+- **Fence**: Use a markdown code fence with **no language tag** so the font stays monospace.
+- **Symbols**: Boxes (`┌─┐` or `+---+`), labels, buttons like `[Submit]`, single-line inputs like `[________________]`.
+- **Multiple screens**: Separate sketches with a short `### Screen: …` heading.
+- **Disclaimer**: One line such as “Wireframe is indicative; final layout may differ.”
+
+Example:
+
+```text
++----------------------------------------------------------+
+|  App title                              [@user] [Settings]|
++----------------------------------------------------------+
+|  Sidebar          |  Main                                |
+|  - Item A         |  +----------------------------------+ |
+|  - Item B         |  |  Primary content                 | |
+|                   |  +----------------------------------+ |
+|                   |  [ Cancel ]  [ Save ]                |
++-------------------+--------------------------------------+
+```
+
+## Labels
+
+Before passing `--label`, list labels with `gh label list` or confirm names in the GitHub UI. Unknown labels may cause `gh issue create` to fail.


### PR DESCRIPTION
# Add gh-issue-create Cursor skill

## Summary

Adds an Agent Skill that drafts GitHub issue titles and bodies from a user prompt, includes ASCII wireframes for frontend/UI work, and only runs `gh issue create` after explicit approval. A short reference file documents body structure and ASCII conventions.

## Base branch

main

## Changes

- Add `.cursor/skills/gh-issue-create/SKILL.md` with workflow, approval gate, `gh issue create` usage, and links to `gh-issue-to-pr` and `pr` skills.
- Add `.cursor/skills/gh-issue-create/references/ISSUE_BODY_GUIDE.md` for issue body sections and ASCII wireframe rules.

## How to test

1. Open Cursor **Settings → Rules** and confirm **`gh-issue-create`** appears under Agent skills (or invoke with `/gh-issue-create`).
2. Ask the agent to draft an issue from a sample prompt; confirm it proposes title/body first and does not create until you approve.
3. Optional: `gh issue create --help` to verify flags used in the skill match your `gh` version.

## Screenshots / recording

N/A — documentation-only change (no app UI).

### Before

N/A

### After

N/A

### Demo video (optional)

N/A

## Checklist

- [x] `npm run lint` passes (or note exception).
- [x] No secrets or env values in code or PR text.
- [x] Breaking changes documented if any (none).
