### PR TITLE
Show user message immediately; animate typing dots while assistant replies

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -10,3 +10,37 @@ body,
 body {
   @apply bg-white text-zinc-900 antialiased;
 }
+
+@keyframes typing-dot-wave {
+  0%,
+  80%,
+  100% {
+    opacity: 0.35;
+  }
+  40% {
+    opacity: 1;
+  }
+}
+
+.typing-dots .typing-dot {
+  animation: typing-dot-wave 1.05s ease-in-out infinite;
+}
+
+.typing-dots .typing-dot:nth-child(1) {
+  animation-delay: 0ms;
+}
+
+.typing-dots .typing-dot:nth-child(2) {
+  animation-delay: 150ms;
+}
+
+.typing-dots .typing-dot:nth-child(3) {
+  animation-delay: 300ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typing-dots .typing-dot {
+    animation: none;
+    opacity: 0.75;
+  }
+}

--- a/src/app.svelte
+++ b/src/app.svelte
@@ -8,6 +8,7 @@
   import PanelTitle from './components/panel-title'
   import TextArea from './components/text-area'
   import TextField from './components/text-field'
+  import TypingDots from './components/typing-dots'
   import * as pageTree from './lib/pages-helpers'
   import type { PageDetail, PageMeta, SearchHit } from './lib/types'
 
@@ -181,10 +182,11 @@
   async function sendChat() {
     const msg = chatInput.trim()
     if (!msg || chatBusy) return
-    chatBusy = true
     err = ''
-    const messages: AgentChatMessage[] = [...chatMessages, { role: 'user', content: msg }]
+    chatMessages = [...chatMessages, { role: 'user', content: msg }]
     chatInput = ''
+    chatBusy = true
+    const messages: AgentChatMessage[] = [...chatMessages]
     try {
       const result = await invoke<AgentChatResult>('agent_chat', {
         model,
@@ -427,7 +429,7 @@
             {/if}
           {/each}
           {#if chatBusy}
-            <p class="text-zinc-400">…</p>
+            <TypingDots />
           {/if}
         </div>
         <div class="mt-2 flex gap-1">

--- a/src/components/typing-dots/index.ts
+++ b/src/components/typing-dots/index.ts
@@ -1,0 +1,1 @@
+export { default } from './typing-dots.svelte'

--- a/src/components/typing-dots/typing-dots.svelte
+++ b/src/components/typing-dots/typing-dots.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  let { label = 'Assistant is replying' }: { label?: string } = $props()
+</script>
+
+<div class="mb-2 text-emerald-800" role="status" aria-live="polite">
+  <span class="font-semibold">Model:</span>
+  <span class="sr-only">{label}</span>
+  <span
+    class="typing-dots ml-1 inline-flex items-center gap-0.5 align-middle"
+    aria-hidden="true"
+  >
+    <span class="typing-dot inline-block h-1.5 w-1.5 rounded-full bg-emerald-700/80"></span>
+    <span class="typing-dot inline-block h-1.5 w-1.5 rounded-full bg-emerald-700/80"></span>
+    <span class="typing-dot inline-block h-1.5 w-1.5 rounded-full bg-emerald-700/80"></span>
+  </span>
+</div>

--- a/src/components/typing-dots/typing-dots.test.ts
+++ b/src/components/typing-dots/typing-dots.test.ts
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+
+import TypingDots from './typing-dots.svelte'
+
+describe('TypingDots', () => {
+  it('renders as a pending status with a screen-reader label', () => {
+    render(TypingDots, { props: { label: 'Working…' } })
+    const status = screen.getByRole('status')
+    expect(status).toBeTruthy()
+    expect(screen.getByText('Working…')).toBeTruthy()
+  })
+
+  it('uses default assistant label', () => {
+    render(TypingDots)
+    expect(screen.getByText('Assistant is replying')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Implements [#7](https://github.com/Boccochan/lote/issues/7): the Ollama chat panel now appends the user message to the thread **before** the `agent_chat` call returns, so there is no empty gap with only a loading hint. While the assistant is working, a dedicated **Model** row shows three dots with a sequential opacity wave. `prefers-reduced-motion: reduce` disables the animation and uses steady opacity instead.

## Base branch

`main`

## Changes

- **`sendChat`** — Update `chatMessages` with the user turn immediately, then set `chatBusy` and invoke the agent with the same message list.
- **`TypingDots`** — New component: `role="status"`, `aria-live="polite"`, visible **Model:** label, screen-reader text, three animated dots (matches assistant styling).
- **`app.css`** — `@keyframes typing-dot-wave`, staggered delays, reduced-motion override.

## How to test

1. `npm run test` — unit tests (includes `TypingDots`).
2. `npm run lint` and `npm run check`.
3. Manual: `npm run tauri:dev`, open a page, send a chat message. Confirm your text appears immediately and animated dots show until the reply; toggle OS “reduce motion” and confirm dots stop animating.

## Screenshots / recording

### Before

On `main`, after send: user line is missing until the response completes; only static `…` appears.

### After

User line appears right away; pending assistant row shows **Model:** with animated dots.

### Demo video (optional)

Not attached; a short screen recording can show send → immediate user bubble → animated dots → assistant reply.

## Checklist

- [x] `npm run lint` passes.
- [x] No secrets or env values in code or PR text.
- [x] Breaking changes documented if any — none.
