### PR TITLE
Add Settings sidebar entry and placeholder Settings view

### DIFF
--- a/src/app.svelte
+++ b/src/app.svelte
@@ -53,6 +53,10 @@
   let searchHits = $state<SearchHit[]>([])
   let searchBusy = $state(false)
 
+  /** Main center column: page editor vs placeholder Settings. */
+  type MainView = 'editor' | 'settings'
+  let mainView = $state<MainView>('editor')
+
   async function loadPages() {
     err = ''
     try {
@@ -100,6 +104,7 @@
 
   async function openPage(id: string) {
     err = ''
+    mainView = 'editor'
     selectedId = id
     try {
       const d = await invoke<PageDetail>('pages_get', { id })
@@ -242,6 +247,10 @@
     }
   }
 
+  function openSettings() {
+    mainView = 'settings'
+  }
+
   $effect(() => {
     void loadPages()
   })
@@ -300,7 +309,7 @@
         {#each pageTree.orderedPages(pages) as p (p.id)}
           <button
             type="button"
-            class="mb-0.5 w-full rounded-md px-2 py-1.5 text-left text-sm {selectedId === p.id
+            class="mb-0.5 w-full rounded-md px-2 py-1.5 text-left text-sm {selectedId === p.id && mainView === 'editor'
               ? 'bg-zinc-200 text-zinc-900'
               : 'text-zinc-700 hover:bg-zinc-100'}"
             style="padding-left: {0.5 + pageTree.depthOf(p, pages) * 0.75}rem"
@@ -312,42 +321,76 @@
           <p class="px-2 text-xs text-zinc-500">No pages yet</p>
         {/each}
       </nav>
+      <div class="shrink-0 border-t border-zinc-200 p-2">
+        <button
+          type="button"
+          class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm {mainView === 'settings'
+            ? 'bg-zinc-200 text-zinc-900'
+            : 'text-zinc-700 hover:bg-zinc-100'}"
+          onclick={openSettings}
+        >
+          <svg
+            class="h-4 w-4 shrink-0 text-zinc-600"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 00-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.932 6.932 0 010 .255c-.007.378.138.75.43.99l1.005.827c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.37.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 001.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.827a1.125 1.125 0 00-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"
+            />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          Settings
+        </button>
+      </div>
     </aside>
 
-    <!-- Editor -->
+    <!-- Editor or Settings -->
     <main class="flex min-h-0 flex-col">
-      <div class="flex items-center gap-2 border-b border-zinc-200 px-3 py-2">
-        <TextField
-          class="min-w-0 flex-1"
-          placeholder="Title"
-          bind:value={title}
+      {#if mainView === 'settings'}
+        <div class="flex min-h-0 flex-1 flex-col px-6 py-8">
+          <h1 class="text-lg font-semibold text-zinc-900">Settings</h1>
+          <p class="mt-2 text-sm text-zinc-500">Preferences will appear here.</p>
+        </div>
+      {:else}
+        <div class="flex items-center gap-2 border-b border-zinc-200 px-3 py-2">
+          <TextField
+            class="min-w-0 flex-1"
+            placeholder="Title"
+            bind:value={title}
+          />
+          <label class="flex items-center gap-1 text-xs text-zinc-600">
+            Parent
+            <select
+              class="rounded-md border border-zinc-300 bg-white px-1 py-1 text-xs text-zinc-900"
+              bind:value={parentSelect}
+            >
+              <option value="">—</option>
+              {#each pages as p (p.id)}
+                {#if p.id !== selectedId}
+                  <option value={p.id}>{p.title}</option>
+                {/if}
+              {/each}
+            </select>
+          </label>
+          <ActionButton variant="primary" disabled={!selectedId} onclick={() => void savePage()}>Save</ActionButton>
+          <ActionButton variant="danger" disabled={!selectedId} onclick={() => void deletePage()}>Delete</ActionButton>
+          {#if status}
+            <span class="text-xs text-zinc-500">{status}</span>
+          {/if}
+        </div>
+        <TextArea
+          plain
+          class="min-h-0 flex-1 p-4 font-mono text-sm leading-relaxed text-zinc-800"
+          placeholder="Markdown…"
+          bind:value={body}
         />
-        <label class="flex items-center gap-1 text-xs text-zinc-600">
-          Parent
-          <select
-            class="rounded-md border border-zinc-300 bg-white px-1 py-1 text-xs text-zinc-900"
-            bind:value={parentSelect}
-          >
-            <option value="">—</option>
-            {#each pages as p (p.id)}
-              {#if p.id !== selectedId}
-                <option value={p.id}>{p.title}</option>
-              {/if}
-            {/each}
-          </select>
-        </label>
-        <ActionButton variant="primary" disabled={!selectedId} onclick={() => void savePage()}>Save</ActionButton>
-        <ActionButton variant="danger" disabled={!selectedId} onclick={() => void deletePage()}>Delete</ActionButton>
-        {#if status}
-          <span class="text-xs text-zinc-500">{status}</span>
-        {/if}
-      </div>
-      <TextArea
-        plain
-        class="min-h-0 flex-1 p-4 font-mono text-sm leading-relaxed text-zinc-800"
-        placeholder="Markdown…"
-        bind:value={body}
-      />
+      {/if}
     </main>
 
     <!-- Right: AI + MCP -->


### PR DESCRIPTION
# Add Settings sidebar entry and placeholder Settings view

Closes #6.

## Summary

Implements [issue #6](https://github.com/Boccochan/lote/issues/6): a **Settings** row pinned to the bottom of the left sidebar (gear icon + label), a **`mainView`** state toggling between the existing page **editor** and a minimal **Settings** placeholder in the center column, and restored editor behavior when a **page** is selected.

## Base branch

main

## Changes

- Introduce `MainView` (`'editor' | 'settings'`) and `mainView` state; `openPage` sets `mainView` to `'editor'` so page selection and search links return to the editor.
- Restructure the left sidebar: scrollable page list (`<nav class="flex-1 overflow-y-auto">`) with a non-scrolling footer containing the Settings control.
- Settings row: inline Heroicons-style cog SVG to the left of "Settings", active styling when `mainView === 'settings'`.
- Page list highlights the current page only when `mainView === 'editor'` (Settings does not leave a false "selected page" highlight).
- Center `<main>`: conditional — placeholder Settings copy when `mainView === 'settings'`, otherwise unchanged title/parent/save/delete + body editor.

## How to test

1. `npm run dev` (or the Tauri dev command you use) and open the app.
2. Confirm **Settings** sits at the **bottom** of the left column, **below** the scrolling page list, with a **gear** to the left of the label.
3. Click **Settings**: center column shows **Settings** title and short placeholder text; **no** functional preferences.
4. Click any **page** in the tree: center column shows the **editor** again (title, parent, markdown) as before.
5. `npm run lint` — passes.

## Screenshots / recording

### Before

No Settings entry in the sidebar; center column was only the page editor.

### After

Screenshots not attached in-repo; after merge, capture: sidebar with Settings pinned at bottom, and center placeholder after clicking Settings.

### Demo video (optional)

N/A

## Checklist

- [x] `npm run lint` passes (or note exception).
- [x] No secrets or env values in code or PR text.
- [x] Breaking changes documented if any (none).
