### PR TITLE
Show user message immediately; animate typing dots (issue #7)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -10,3 +10,37 @@ body,
 body {
   @apply bg-white text-zinc-900 antialiased;
 }
+
+@keyframes typing-dot-wave {
+  0%,
+  80%,
+  100% {
+    opacity: 0.35;
+  }
+  40% {
+    opacity: 1;
+  }
+}
+
+.typing-dots .typing-dot {
+  animation: typing-dot-wave 1.05s ease-in-out infinite;
+}
+
+.typing-dots .typing-dot:nth-child(1) {
+  animation-delay: 0ms;
+}
+
+.typing-dots .typing-dot:nth-child(2) {
+  animation-delay: 150ms;
+}
+
+.typing-dots .typing-dot:nth-child(3) {
+  animation-delay: 300ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typing-dots .typing-dot {
+    animation: none;
+    opacity: 0.75;
+  }
+}

--- a/src/app.svelte
+++ b/src/app.svelte
@@ -8,6 +8,7 @@
   import PanelTitle from './components/panel-title'
   import TextArea from './components/text-area'
   import TextField from './components/text-field'
+  import TypingDots from './components/typing-dots'
   import * as pageTree from './lib/pages-helpers'
   import type { PageDetail, PageMeta, SearchHit } from './lib/types'
 
@@ -189,6 +190,7 @@
     chatBusy = true
     err = ''
     const messages: AgentChatMessage[] = [...chatMessages, { role: 'user', content: msg }]
+    chatMessages = messages
     chatInput = ''
     try {
       const result = await invoke<AgentChatResult>('agent_chat', {
@@ -472,7 +474,7 @@
             {/if}
           {/each}
           {#if chatBusy}
-            <p class="text-zinc-400">…</p>
+            <TypingDots />
           {/if}
         </div>
         <div class="mt-2 flex gap-1">

--- a/src/components/typing-dots/index.ts
+++ b/src/components/typing-dots/index.ts
@@ -1,0 +1,1 @@
+export { default } from './typing-dots.svelte'

--- a/src/components/typing-dots/typing-dots.stories.ts
+++ b/src/components/typing-dots/typing-dots.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/svelte-vite'
+
+import TypingDots from './typing-dots.svelte'
+
+const meta = {
+  title: 'UI/TypingDots',
+  component: TypingDots,
+  tags: ['autodocs'],
+} satisfies Meta<typeof TypingDots>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const CustomLabel: Story = {
+  args: {
+    label: 'Model is thinking…',
+  },
+}

--- a/src/components/typing-dots/typing-dots.svelte
+++ b/src/components/typing-dots/typing-dots.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  let { label = 'Assistant is replying' }: { label?: string } = $props()
+</script>
+
+<div class="mb-2 text-emerald-800" role="status" aria-live="polite">
+  <span class="font-semibold">Model:</span>
+  <span class="sr-only">{label}</span>
+  <span
+    class="typing-dots ml-1 inline-flex items-center gap-0.5 align-middle"
+    aria-hidden="true"
+  >
+    <span class="typing-dot inline-block h-1.5 w-1.5 rounded-full bg-emerald-700/80"></span>
+    <span class="typing-dot inline-block h-1.5 w-1.5 rounded-full bg-emerald-700/80"></span>
+    <span class="typing-dot inline-block h-1.5 w-1.5 rounded-full bg-emerald-700/80"></span>
+  </span>
+</div>

--- a/src/components/typing-dots/typing-dots.test.ts
+++ b/src/components/typing-dots/typing-dots.test.ts
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+
+import TypingDots from './typing-dots.svelte'
+
+describe('TypingDots', () => {
+  it('renders as a pending status with a screen-reader label', () => {
+    render(TypingDots, { props: { label: 'Working…' } })
+    const status = screen.getByRole('status')
+    expect(status).toBeTruthy()
+    expect(screen.getByText('Working…')).toBeTruthy()
+  })
+
+  it('uses default assistant label', () => {
+    render(TypingDots)
+    expect(screen.getByText('Assistant is replying')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
# Show user message immediately; animate typing dots

## Summary

Implements [issue #7](https://github.com/Boccochan/lote/issues/7): the user's message appears in the Ollama chat panel as soon as they send, and the assistant pending state uses animated dots instead of a static ellipsis, with `prefers-reduced-motion` support.

## Base branch

main

## Changes

- **`sendChat`**: assign `chatMessages` to include the new user message before awaiting `agent_chat`, so the thread updates immediately.
- **`TypingDots`**: new reusable component (`Model:` row, three staggered-opacity dots, `role="status"` and a screen-reader label).
- **`app.css`**: `typing-dot-wave` keyframes, per-dot animation delay, reduced-motion fallback (no animation, steady opacity).
- **Tests / Storybook**: `typing-dots.test.ts`, `typing-dots.stories.ts`.

## How to test

1. `npm run test`, `npm run lint`, `npm run check`
2. Run the app (`npm run tauri:dev` or `npm run dev`), open the Ollama panel, send a message: your text should appear immediately; dots should animate until the assistant reply arrives. With reduced motion enabled in the OS, dots should not animate.

## Screenshots / recording

Tauri desktop capture (`npm run e2e:tauri:capture:publish`) may append screenshots to this PR after it exists.

## Checklist

- [x] `npm run lint` passes
- [x] No secrets or env values in code or PR text
- [x] No breaking API changes
