### PR TITLE
Move MCP client to Settings; expand AI chat column

### DIFF
--- a/src/lib/lote-app-mcp.test.ts
+++ b/src/lib/lote-app-mcp.test.ts
@@ -1,0 +1,32 @@
+import { invoke } from '@tauri-apps/api/core'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { lote, refreshMcpTools, runMcpTool } from './lote-app.svelte'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+describe('lote-app MCP helpers', () => {
+  afterEach(() => {
+    vi.mocked(invoke).mockReset()
+    lote.mcpEndpoint = ''
+    lote.mcpToolArgs = '{}'
+    lote.err = ''
+  })
+
+  it('refreshMcpTools requires an endpoint', async () => {
+    lote.mcpEndpoint = ''
+    await refreshMcpTools()
+    expect(lote.err).toBe('Set MCP endpoint URL first')
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('runMcpTool rejects invalid JSON arguments', async () => {
+    lote.mcpEndpoint = 'http://127.0.0.1:9'
+    lote.mcpToolArgs = 'not-json'
+    await runMcpTool()
+    expect(lote.err).toBe('Tool arguments must be valid JSON')
+    expect(invoke).not.toHaveBeenCalled()
+  })
+})

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -9,8 +9,6 @@
     newPage,
     openPage,
     parseSearchHitsFromTool,
-    refreshMcpTools,
-    runMcpTool,
     runPageSearch,
     sendChat,
   } from '$lib/lote-app.svelte'
@@ -21,7 +19,6 @@
   import ErrorBanner from '../../components/error-banner'
   import JsonPre from '../../components/json-pre'
   import PanelTitle from '../../components/panel-title'
-  import TextArea from '../../components/text-area'
   import TextField from '../../components/text-field'
   import TypingDots from '../../components/typing-dots'
 
@@ -131,9 +128,9 @@
       {@render children()}
     </main>
 
-    <!-- Right: AI + MCP -->
+    <!-- Right: Ollama / AI chat (full column height) -->
     <aside class="flex min-h-0 flex-col border-l border-zinc-200 bg-zinc-50/50">
-      <section class="flex min-h-0 flex-1 flex-col border-b border-zinc-200 p-3">
+      <section class="flex min-h-0 flex-1 flex-col p-3">
         <PanelTitle>Ollama</PanelTitle>
         <TextField
           class="mb-2 w-full text-xs"
@@ -218,44 +215,6 @@
           />
           <ActionButton disabled={lote.chatBusy} onclick={() => void sendChat()}>Send</ActionButton>
         </div>
-      </section>
-
-      <section class="flex max-h-[45%] min-h-0 flex-col p-3">
-        <PanelTitle>MCP client</PanelTitle>
-        <TextField
-          class="mb-2 w-full text-xs"
-          placeholder="MCP HTTP endpoint (JSON-RPC POST)"
-          bind:value={lote.mcpEndpoint}
-        />
-        <div class="mb-2 flex gap-1">
-          <ActionButton onclick={() => void refreshMcpTools()}>List tools</ActionButton>
-        </div>
-        <JsonPre
-          class="mb-2 max-h-24 min-h-0 p-2 text-[10px] text-zinc-600"
-          text={lote.mcpToolsRaw}
-        />
-        <TextField
-          class="mb-1 w-full text-xs"
-          placeholder="tool name"
-          bind:value={lote.mcpToolName}
-        />
-        <TextArea
-          class="mb-2 min-h-[52px] w-full px-2 py-1 font-mono text-[10px]"
-          placeholder="JSON object for arguments"
-          bind:value={lote.mcpToolArgs}
-        />
-        <ActionButton class="mb-2" onclick={() => void runMcpTool()}>Call tool</ActionButton>
-        <JsonPre
-          class="min-h-0 flex-1 p-2 text-[10px] text-zinc-700"
-          text={lote.mcpResult}
-        />
-      </section>
-
-      <section class="border-t border-zinc-200 p-3">
-        <PanelTitle tone="muted" class="!mb-1">MCP server (stub)</PanelTitle>
-        <p class="text-[10px] leading-snug text-zinc-500">
-          Exposing this app as an MCP server for cloud AIs is not implemented in this MVP.
-        </p>
       </section>
     </aside>
   </div>

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -1,11 +1,59 @@
+<script lang="ts">
+  import { lote, refreshMcpTools, runMcpTool } from '$lib/lote-app.svelte'
+
+  import ActionButton from '../../../components/action-button'
+  import JsonPre from '../../../components/json-pre'
+  import PanelTitle from '../../../components/panel-title'
+  import TextArea from '../../../components/text-area'
+  import TextField from '../../../components/text-field'
+</script>
+
 <div
-  class="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 py-8"
+  class="flex min-h-0 flex-1 flex-col overflow-hidden px-6 py-6"
   data-testid="settings-view"
 >
-  <h1 class="text-lg font-semibold text-zinc-900">Settings</h1>
-  <p class="mt-2 max-w-xl text-sm leading-relaxed text-zinc-600">
-    This screen is served at <code class="rounded bg-zinc-100 px-1 py-0.5 text-xs">/settings</code>. Open it from
-    the <strong class="font-medium text-zinc-800">Settings</strong> item at the bottom of the left sidebar.
+  <h1 class="shrink-0 text-lg font-semibold text-zinc-900">Settings</h1>
+  <p class="mt-1 max-w-xl shrink-0 text-sm leading-relaxed text-zinc-600">
+    Connection options for the in-app MCP client. The same values are used if the agent integrates with MCP later.
   </p>
-  <p class="mt-2 text-sm text-zinc-500">Preferences will appear here.</p>
+
+  <div class="mt-4 min-h-0 flex-1 space-y-8 overflow-y-auto pr-1">
+    <section class="flex flex-col" data-testid="settings-mcp-client">
+      <PanelTitle>MCP client</PanelTitle>
+      <TextField
+        class="mb-2 w-full max-w-xl text-xs"
+        placeholder="MCP HTTP endpoint (JSON-RPC POST)"
+        bind:value={lote.mcpEndpoint}
+      />
+      <div class="mb-2 flex gap-1">
+        <ActionButton onclick={() => void refreshMcpTools()}>List tools</ActionButton>
+      </div>
+      <JsonPre
+        class="mb-2 max-h-48 min-h-0 w-full max-w-xl p-2 text-[10px] text-zinc-600"
+        text={lote.mcpToolsRaw}
+      />
+      <TextField
+        class="mb-1 w-full max-w-xl text-xs"
+        placeholder="tool name"
+        bind:value={lote.mcpToolName}
+      />
+      <TextArea
+        class="mb-2 min-h-[52px] w-full max-w-xl px-2 py-1 font-mono text-[10px]"
+        placeholder="JSON object for arguments"
+        bind:value={lote.mcpToolArgs}
+      />
+      <ActionButton class="mb-2" onclick={() => void runMcpTool()}>Call tool</ActionButton>
+      <JsonPre
+        class="min-h-[10rem] w-full max-w-xl p-2 text-[10px] text-zinc-700"
+        text={lote.mcpResult}
+      />
+    </section>
+
+    <section class="max-w-xl border-t border-zinc-200 pt-6">
+      <PanelTitle tone="muted" class="!mb-1">MCP server (stub)</PanelTitle>
+      <p class="text-[10px] leading-snug text-zinc-500">
+        Exposing this app as an MCP server for cloud AIs is not implemented in this MVP.
+      </p>
+    </section>
+  </div>
 </div>


### PR DESCRIPTION
## Summary

Implements #15: MCP client UI and the MCP server stub live under **Settings** (`/settings`). The right column is **Ollama / AI chat** only so the transcript uses the full column height.

## Changes

- Settings page: full MCP client (endpoint, list tools, call tool, JSON areas) + stub notice; `data-testid="settings-mcp-client"`.
- App layout: removed MCP sections from the right column; single full-height Ollama panel.
- `lote-app-mcp.test.ts`: unit tests for MCP validation paths (mocked `invoke`).

MCP state remains on `lote` in `lote-app.svelte.ts`.

## How to test

1. Open **Settings** from the sidebar; exercise List tools / Call tool.
2. Confirm the right column has only Ollama chat (taller transcript area).
3. `npm run lint`, `npm run check`, `npm run test -- --project=unit`.

Fixes #15

<!-- pr-auto-media:begin -->
## Screenshots (auto-uploaded)

_Hosted on GitHub Gist (not in this repository): https://gist.github.com/Boccochan/3f2f72382b980cab8fd6e462a6d11333_

### 01-initial.png

![01-initial.png](https://gist.githubusercontent.com/Boccochan/3f2f72382b980cab8fd6e462a6d11333/raw/0f206238ba2e7c163693bcfb6915abd1d169c0ba/01-initial.png)

### 02-after-new-page.png

![02-after-new-page.png](https://gist.githubusercontent.com/Boccochan/3f2f72382b980cab8fd6e462a6d11333/raw/59e5d54d36e5c5836cce2045dbf9cf2f4d1afb1f/02-after-new-page.png)

### 03-title-edited.png

![03-title-edited.png](https://gist.githubusercontent.com/Boccochan/3f2f72382b980cab8fd6e462a6d11333/raw/bfcdb9609b1575cc63eeeb6bd56424d50a1e598d/03-title-edited.png)

### 04-settings-empty.png

![04-settings-empty.png](https://gist.githubusercontent.com/Boccochan/3f2f72382b980cab8fd6e462a6d11333/raw/b52e75b9d481298914fcb0d60c581a0741e06aa6/04-settings-empty.png)

<!-- pr-auto-media:end -->
