### PR TITLE
feat(agent): confirm AI page mutations before apply (fixes #19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ Prefer **`kebab-case`** values on the DOM (`data-testid="my-target"`). Reusable 
 | `lote-app` | Root shell in `src/routes/(app)/+layout.svelte` | Wait for app ready |
 | `btn-new-root-page` | “+ Page” in `src/routes/(app)/+layout.svelte` | Create root page in capture flow |
 | `editor-title` | Title field in `src/routes/(app)/+page.svelte` | Editor / title editing in capture flow |
+| `editor-body` | Body textarea in `src/routes/(app)/+page.svelte` (`TextArea`) | Seed long document before save-proposal capture |
+| `editor-save` | Save button in `src/routes/(app)/+page.svelte` | Persist editor before save-proposal diff screenshot |
 | `sidebar-settings` | Settings link in `src/routes/(app)/+layout.svelte` | Open `/settings` in capture flow (when present) |
 | `settings-view` | Settings panel in `src/routes/(app)/settings/+page.svelte` | Assert Settings view in capture flow (when present) |
 | `chat-input` | Chat message field in `src/routes/(app)/+layout.svelte` | Optional: chat input in capture flow |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,8 @@ Prefer **`kebab-case`** values on the DOM (`data-testid="my-target"`). Reusable 
 | `settings-view` | Settings panel in `src/routes/(app)/settings/+page.svelte` | Assert Settings view in capture flow (when present) |
 | `chat-input` | Chat message field in `src/routes/(app)/+layout.svelte` | Optional: chat input in capture flow |
 | `chat-send` | Send button next to chat input | Optional: send in capture flow |
-| `chat-proposal-confirm` | Confirm on pending AI page proposal | Approve `propose_page_*` in capture flow |
+| `chat-proposal-panel` | Approval card in chat (`chat-proposal-approval.svelte`) | Review before/after or delete prompt |
+| `chat-proposal-approve` | Approve on pending AI page proposal | Apply `propose_page_*` in capture flow |
 | `chat-proposal-cancel` | Cancel on pending AI page proposal | Dismiss proposal in capture flow |
 
 Add or update a row **in the same PR** whenever you introduce or rename a `data-testid` used by `e2e-tauri/specs/desktop-capture.e2e.js` (or by a sibling spec under `e2e-tauri/specs/`). Remove rows if selectors are deleted from the spec.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ Prefer **`kebab-case`** values on the DOM (`data-testid="my-target"`). Reusable 
 | `chat-proposal-panel` | Approval card in chat (`chat-proposal-approval.svelte`) | Review before/after or delete prompt |
 | `chat-proposal-approve` | Approve on pending AI page proposal | Apply `propose_page_*` in capture flow |
 | `chat-proposal-cancel` | Cancel on pending AI page proposal | Dismiss proposal in capture flow |
+| `chat-proposal-body-collapsed` | “省略” row when long unchanged runs are folded (`chat-proposal-approval.svelte`) | Scroll into view before save-proposal capture |
 
 Add or update a row **in the same PR** whenever you introduce or rename a `data-testid` used by `e2e-tauri/specs/desktop-capture.e2e.js` (or by a sibling spec under `e2e-tauri/specs/`). Remove rows if selectors are deleted from the spec.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,13 @@ Prefer **`kebab-case`** values on the DOM (`data-testid="my-target"`). Reusable 
 | `editor-title` | Title field in `src/routes/(app)/+page.svelte` | Editor / title editing in capture flow |
 | `sidebar-settings` | Settings link in `src/routes/(app)/+layout.svelte` | Open `/settings` in capture flow (when present) |
 | `settings-view` | Settings panel in `src/routes/(app)/settings/+page.svelte` | Assert Settings view in capture flow (when present) |
+| `chat-input` | Chat message field in `src/routes/(app)/+layout.svelte` | Optional: chat input in capture flow |
+| `chat-send` | Send button next to chat input | Optional: send in capture flow |
+| `chat-proposal-confirm` | Confirm on pending AI page proposal | Approve `propose_page_*` in capture flow |
+| `chat-proposal-cancel` | Cancel on pending AI page proposal | Dismiss proposal in capture flow |
 
 Add or update a row **in the same PR** whenever you introduce or rename a `data-testid` used by `e2e-tauri/specs/desktop-capture.e2e.js` (or by a sibling spec under `e2e-tauri/specs/`). Remove rows if selectors are deleted from the spec.
+
+Desktop PR capture builds with `VITE_E2E_CAPTURE=true` (see `e2e-tauri/wdio.conf.js`) so the app exposes `window.__loteSeedAgentDemo` for scripted screenshots of the agent proposal UI without a live Ollama round-trip.
 
 **Skill smoke test:** Use throwaway branches (for example `chore/skill-workflow-smoke`) to verify `gh pr create` plus optional `e2e:tauri:capture:publish`; merge or close the PR after confirming the workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Prefer **`kebab-case`** values on the DOM (`data-testid="my-target"`). Reusable 
 | `chat-proposal-panel` | Approval card in chat (`chat-proposal-approval.svelte`) | Review before/after or delete prompt |
 | `chat-proposal-approve` | Approve on pending AI page proposal | Apply `propose_page_*` in capture flow |
 | `chat-proposal-cancel` | Cancel on pending AI page proposal | Dismiss proposal in capture flow |
-| `chat-proposal-body-collapsed` | “省略” row when long unchanged runs are folded (`chat-proposal-approval.svelte`) | Scroll into view before save-proposal capture |
+| `chat-proposal-body-collapsed` | “Omitted” row when long unchanged runs are folded (`chat-proposal-approval.svelte`) | Scroll into view before save-proposal capture |
 
 Add or update a row **in the same PR** whenever you introduce or rename a `data-testid` used by `e2e-tauri/specs/desktop-capture.e2e.js` (or by a sibling spec under `e2e-tauri/specs/`). Remove rows if selectors are deleted from the spec.
 

--- a/e2e-tauri/specs/desktop-capture.e2e.js
+++ b/e2e-tauri/specs/desktop-capture.e2e.js
@@ -53,6 +53,10 @@ describe('Lote desktop capture', () => {
       await globalThis.__loteSeedAgentDemo?.('save')
     })
     await browser.pause(400)
+    const collapsedRow = await browser.$('[data-testid="chat-proposal-body-collapsed"]')
+    await collapsedRow.waitForDisplayed({ timeout: 15_000 })
+    await collapsedRow.scrollIntoView({ block: 'center' })
+    await browser.pause(200)
     await browser.saveScreenshot(shot('04-ai-propose-edit.png'))
 
     const confirmSave = await browser.$('[data-testid="chat-proposal-approve"]')

--- a/e2e-tauri/specs/desktop-capture.e2e.js
+++ b/e2e-tauri/specs/desktop-capture.e2e.js
@@ -9,6 +9,17 @@ function shot(name) {
   return file
 }
 
+/** Must match `e2eLongDocBefore()` in `src/lib/e2e-long-doc-fixture.ts`. */
+function e2eLongDocBefore() {
+  const lines = []
+  for (let i = 1; i <= 100; i++) {
+    lines.push(
+      `Line ${i}: Lorem ipsum dolor sit amet, placeholder content for capture demo.`,
+    )
+  }
+  return lines.join('\n')
+}
+
 describe('Lote desktop capture', () => {
   it('captures AI agent proposal flow (create → edit → delete) and basic shell', async () => {
     const root = await browser.$('[data-testid="lote-app"]')
@@ -28,6 +39,15 @@ describe('Lote desktop capture', () => {
     await confirmCreate.click()
     await browser.pause(800)
     await browser.saveScreenshot(shot('03-ai-after-create-page-exists.png'))
+
+    const editorBody = await browser.$('[data-testid="editor-body"]')
+    await editorBody.waitForDisplayed({ timeout: 15_000 })
+    await editorBody.setValue(e2eLongDocBefore())
+    await browser.pause(200)
+    const editorSave = await browser.$('[data-testid="editor-save"]')
+    await editorSave.waitForClickable({ timeout: 15_000 })
+    await editorSave.click()
+    await browser.pause(800)
 
     await browser.execute(async () => {
       await globalThis.__loteSeedAgentDemo?.('save')

--- a/e2e-tauri/specs/desktop-capture.e2e.js
+++ b/e2e-tauri/specs/desktop-capture.e2e.js
@@ -17,37 +17,37 @@ describe('Lote desktop capture', () => {
 
     await browser.saveScreenshot(shot('01-app-ready.png'))
 
-    await browser.execute(() => {
-      globalThis.__loteSeedAgentDemo?.('create')
+    await browser.execute(async () => {
+      await globalThis.__loteSeedAgentDemo?.('create')
     })
     await browser.pause(400)
     await browser.saveScreenshot(shot('02-ai-propose-create.png'))
 
-    const confirmCreate = await browser.$('[data-testid="chat-proposal-confirm"]')
+    const confirmCreate = await browser.$('[data-testid="chat-proposal-approve"]')
     await confirmCreate.waitForClickable({ timeout: 15_000 })
     await confirmCreate.click()
     await browser.pause(800)
     await browser.saveScreenshot(shot('03-ai-after-create-page-exists.png'))
 
-    await browser.execute(() => {
-      globalThis.__loteSeedAgentDemo?.('save')
+    await browser.execute(async () => {
+      await globalThis.__loteSeedAgentDemo?.('save')
     })
     await browser.pause(400)
     await browser.saveScreenshot(shot('04-ai-propose-edit.png'))
 
-    const confirmSave = await browser.$('[data-testid="chat-proposal-confirm"]')
+    const confirmSave = await browser.$('[data-testid="chat-proposal-approve"]')
     await confirmSave.waitForClickable({ timeout: 15_000 })
     await confirmSave.click()
     await browser.pause(800)
     await browser.saveScreenshot(shot('05-ai-after-edit.png'))
 
-    await browser.execute(() => {
-      globalThis.__loteSeedAgentDemo?.('delete')
+    await browser.execute(async () => {
+      await globalThis.__loteSeedAgentDemo?.('delete')
     })
     await browser.pause(400)
     await browser.saveScreenshot(shot('06-ai-propose-delete.png'))
 
-    const confirmDel = await browser.$('[data-testid="chat-proposal-confirm"]')
+    const confirmDel = await browser.$('[data-testid="chat-proposal-approve"]')
     await confirmDel.waitForClickable({ timeout: 15_000 })
     await confirmDel.click()
     await browser.pause(800)

--- a/e2e-tauri/specs/desktop-capture.e2e.js
+++ b/e2e-tauri/specs/desktop-capture.e2e.js
@@ -10,26 +10,62 @@ function shot(name) {
 }
 
 describe('Lote desktop capture', () => {
-  it('loads, creates a page, edits title, saves screenshots (and optional video inputs)', async () => {
+  it('captures AI agent proposal flow (create → edit → delete) and basic shell', async () => {
     const root = await browser.$('[data-testid="lote-app"]')
     await root.waitForDisplayed({ timeout: 30_000 })
     await browser.pause(800)
 
-    await browser.saveScreenshot(shot('01-initial.png'))
+    await browser.saveScreenshot(shot('01-app-ready.png'))
+
+    await browser.execute(() => {
+      globalThis.__loteSeedAgentDemo?.('create')
+    })
+    await browser.pause(400)
+    await browser.saveScreenshot(shot('02-ai-propose-create.png'))
+
+    const confirmCreate = await browser.$('[data-testid="chat-proposal-confirm"]')
+    await confirmCreate.waitForClickable({ timeout: 15_000 })
+    await confirmCreate.click()
+    await browser.pause(800)
+    await browser.saveScreenshot(shot('03-ai-after-create-page-exists.png'))
+
+    await browser.execute(() => {
+      globalThis.__loteSeedAgentDemo?.('save')
+    })
+    await browser.pause(400)
+    await browser.saveScreenshot(shot('04-ai-propose-edit.png'))
+
+    const confirmSave = await browser.$('[data-testid="chat-proposal-confirm"]')
+    await confirmSave.waitForClickable({ timeout: 15_000 })
+    await confirmSave.click()
+    await browser.pause(800)
+    await browser.saveScreenshot(shot('05-ai-after-edit.png'))
+
+    await browser.execute(() => {
+      globalThis.__loteSeedAgentDemo?.('delete')
+    })
+    await browser.pause(400)
+    await browser.saveScreenshot(shot('06-ai-propose-delete.png'))
+
+    const confirmDel = await browser.$('[data-testid="chat-proposal-confirm"]')
+    await confirmDel.waitForClickable({ timeout: 15_000 })
+    await confirmDel.click()
+    await browser.pause(800)
+    await browser.saveScreenshot(shot('07-ai-after-delete.png'))
 
     const newPageBtn = await browser.$('[data-testid="btn-new-root-page"]')
     await newPageBtn.waitForClickable({ timeout: 15_000 })
     await newPageBtn.click()
     await browser.pause(600)
 
-    await browser.saveScreenshot(shot('02-after-new-page.png'))
+    await browser.saveScreenshot(shot('08-shell-new-page-smoke.png'))
 
     const titleInput = await browser.$('[data-testid="editor-title"]')
     await titleInput.waitForDisplayed({ timeout: 15_000 })
     await titleInput.setValue('E2E snapshot title')
     await browser.pause(400)
 
-    await browser.saveScreenshot(shot('03-title-edited.png'))
+    await browser.saveScreenshot(shot('09-shell-title-edited.png'))
 
     const settingsBtn = await browser.$('[data-testid="sidebar-settings"]')
     await settingsBtn.waitForClickable({ timeout: 15_000 })
@@ -38,6 +74,6 @@ describe('Lote desktop capture', () => {
 
     const settingsView = await browser.$('[data-testid="settings-view"]')
     await settingsView.waitForDisplayed({ timeout: 15_000 })
-    await browser.saveScreenshot(shot('04-settings-empty.png'))
+    await browser.saveScreenshot(shot('10-settings.png'))
   })
 })

--- a/e2e-tauri/wdio.conf.js
+++ b/e2e-tauri/wdio.conf.js
@@ -73,10 +73,16 @@ export const config = {
   onPrepare: () => {
     const outDir = path.join(root, 'docs', 'pr-assets', 'tauri-desktop')
     fs.mkdirSync(outDir, { recursive: true })
+    for (const name of fs.readdirSync(outDir)) {
+      if (name.endsWith('.png')) {
+        fs.unlinkSync(path.join(outDir, name))
+      }
+    }
     const build = spawnSync('npm', ['run', 'tauri', 'build', '--', '--debug', '--no-bundle'], {
       cwd: root,
       stdio: 'inherit',
       shell: true,
+      env: { ...process.env, VITE_E2E_CAPTURE: 'true' },
     })
     if (build.status !== 0) {
       process.exit(build.status ?? 1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "lote",
       "version": "0.0.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.10.1"
+        "@tauri-apps/api": "^2.10.1",
+        "diff": "^8.0.4"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -5394,7 +5395,6 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
       "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.10.1"
+    "@tauri-apps/api": "^2.10.1",
+    "diff": "^8.0.4"
   }
 }

--- a/src-tauri/src/agent/registry.rs
+++ b/src-tauri/src/agent/registry.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 use tauri::AppHandle;
 
-use crate::agent::types::ToolDefinition;
+use crate::agent::types::{PageProposal, ToolDefinition};
 use crate::commands::pages::search_pages;
 
 #[async_trait]
@@ -33,6 +33,9 @@ impl ToolRegistry {
         let mut r = Self::new();
         r.register(Arc::new(EchoTool));
         r.register(Arc::new(SearchPagesTool(app)));
+        r.register(Arc::new(ProposePageCreateTool));
+        r.register(Arc::new(ProposePageSaveTool));
+        r.register(Arc::new(ProposePageDeleteTool));
         r
     }
 
@@ -42,11 +45,7 @@ impl ToolRegistry {
     }
 
     pub fn definitions(&self) -> Vec<ToolDefinition> {
-        let mut v: Vec<ToolDefinition> = self
-            .handlers
-            .values()
-            .map(|h| h.definition())
-            .collect();
+        let mut v: Vec<ToolDefinition> = self.handlers.values().map(|h| h.definition()).collect();
         v.sort_by(|a, b| a.function.name.cmp(&b.function.name));
         v
     }
@@ -70,6 +69,13 @@ impl ToolRegistry {
     pub(crate) fn with_echo_only() -> Self {
         let mut r = Self::new();
         r.register(Arc::new(EchoTool));
+        r
+    }
+
+    /// Proposal delete tool only (agent loop short-circuit tests).
+    pub(crate) fn with_propose_delete_only() -> Self {
+        let mut r = Self::new();
+        r.register(Arc::new(ProposePageDeleteTool));
         r
     }
 }
@@ -155,6 +161,155 @@ impl ToolHandler for SearchPagesTool {
     }
 }
 
+/// Records a create-page proposal as JSON; does **not** call `pages_create` (user confirms in the UI).
+struct ProposePageCreateTool;
+
+#[async_trait]
+impl ToolHandler for ProposePageCreateTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            typ: "function".into(),
+            function: crate::agent::types::ToolFunctionDef {
+                name: "propose_page_create".into(),
+                description: "Propose creating a new markdown page. Does not create anything until the user confirms in the app."
+                    .into(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "title": { "type": "string", "description": "Title for the new page." },
+                        "parent_id": { "type": "string", "description": "Optional parent page id; omit or empty for a root-level page." }
+                    },
+                    "required": ["title"]
+                }),
+            },
+        }
+    }
+
+    async fn invoke(&self, arguments: &Value) -> Result<String, String> {
+        let title = arguments
+            .get("title")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "missing title".to_string())?
+            .to_string();
+        let parent_id = arguments
+            .get("parent_id")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let proposal = PageProposal {
+            op: "create".into(),
+            page_id: None,
+            title: Some(title),
+            parent_id,
+            body: None,
+        };
+        serde_json::to_string(&proposal).map_err(|e| e.to_string())
+    }
+}
+
+/// Records an update proposal; does **not** call `pages_save` until the user confirms.
+struct ProposePageSaveTool;
+
+#[async_trait]
+impl ToolHandler for ProposePageSaveTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            typ: "function".into(),
+            function: crate::agent::types::ToolFunctionDef {
+                name: "propose_page_save".into(),
+                description: "Propose saving (replacing) an existing page's title, parent, and body. Does not write until the user confirms."
+                    .into(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "page_id": { "type": "string", "description": "Id of the page to update." },
+                        "title": { "type": "string", "description": "New title." },
+                        "parent_id": { "type": "string", "description": "Parent page id, or empty/null for root." },
+                        "body": { "type": "string", "description": "New markdown body text." }
+                    },
+                    "required": ["page_id", "title", "body"]
+                }),
+            },
+        }
+    }
+
+    async fn invoke(&self, arguments: &Value) -> Result<String, String> {
+        let page_id = arguments
+            .get("page_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "missing page_id".to_string())?
+            .to_string();
+        let title = arguments
+            .get("title")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "missing title".to_string())?
+            .to_string();
+        let body = arguments
+            .get("body")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "missing body".to_string())?
+            .to_string();
+        let parent_id = arguments
+            .get("parent_id")
+            .and_then(|v| if v.is_null() { None } else { v.as_str() })
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let proposal = PageProposal {
+            op: "save".into(),
+            page_id: Some(page_id),
+            title: Some(title),
+            parent_id,
+            body: Some(body),
+        };
+        serde_json::to_string(&proposal).map_err(|e| e.to_string())
+    }
+}
+
+/// Records a delete proposal; does **not** call `pages_delete` until the user confirms.
+struct ProposePageDeleteTool;
+
+#[async_trait]
+impl ToolHandler for ProposePageDeleteTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            typ: "function".into(),
+            function: crate::agent::types::ToolFunctionDef {
+                name: "propose_page_delete".into(),
+                description: "Propose deleting a page by id. Does not delete until the user confirms in the app."
+                    .into(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "page_id": { "type": "string", "description": "Id of the page to delete." },
+                        "title": { "type": "string", "description": "Optional title for display in the confirmation UI." }
+                    },
+                    "required": ["page_id"]
+                }),
+            },
+        }
+    }
+
+    async fn invoke(&self, arguments: &Value) -> Result<String, String> {
+        let page_id = arguments
+            .get("page_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "missing page_id".to_string())?
+            .to_string();
+        let title = arguments
+            .get("title")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let proposal = PageProposal {
+            op: "delete".into(),
+            page_id: Some(page_id),
+            title,
+            parent_id: None,
+            body: None,
+        };
+        serde_json::to_string(&proposal).map_err(|e| e.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,5 +329,21 @@ mod tests {
         let r = ToolRegistry::with_echo_only();
         let defs = r.definitions();
         assert!(defs.iter().any(|d| d.function.name == "echo"));
+    }
+
+    #[tokio::test]
+    async fn propose_page_delete_returns_json_proposal() {
+        let r = ToolRegistry::with_propose_delete_only();
+        let out = r
+            .invoke(
+                "propose_page_delete",
+                &json!({ "page_id": "abc", "title": "Hi" }),
+            )
+            .await
+            .unwrap();
+        let p: PageProposal = serde_json::from_str(&out).unwrap();
+        assert_eq!(p.op, "delete");
+        assert_eq!(p.page_id.as_deref(), Some("abc"));
+        assert_eq!(p.title.as_deref(), Some("Hi"));
     }
 }

--- a/src-tauri/src/agent/runner.rs
+++ b/src-tauri/src/agent/runner.rs
@@ -3,7 +3,9 @@
 use crate::agent::client::{AssistantTurn, ChatCompletionClient};
 use crate::agent::error::AgentError;
 use crate::agent::registry::ToolRegistry;
-use crate::agent::types::{AgentChatResult, ChatMessage, ToolCall, ToolCallFunction};
+use crate::agent::types::{
+    is_proposal_tool_name, AgentChatResult, ChatMessage, PageProposal, ToolCall, ToolCallFunction,
+};
 use serde_json::Value;
 
 /// When the model prints tool JSON in a markdown fence instead of using native `tool_calls`, parse and run it if the name is registered.
@@ -134,6 +136,7 @@ pub async fn run_agent_loop(
                 assistant_reply: content,
                 steps_used,
                 debug_trace,
+                pending_proposal: None,
             });
         }
 
@@ -153,9 +156,11 @@ pub async fn run_agent_loop(
         };
 
         messages.push(ChatMessage::assistant(
-            assistant_content,
+            assistant_content.clone(),
             Some(tool_calls.clone()),
         ));
+
+        let mut pending_proposal: Option<PageProposal> = None;
 
         for tc in tool_calls {
             let name = tc.function.name.as_str();
@@ -185,7 +190,27 @@ pub async fn run_agent_loop(
                     ellipsize_chars(result.trim(), 400)
                 ),
             );
+            if is_proposal_tool_name(name) {
+                let proposal: PageProposal = serde_json::from_str(&result).map_err(|e| {
+                    AgentError::Provider(format!("proposal tool returned invalid JSON: {e}"))
+                })?;
+                pending_proposal = Some(proposal);
+            }
             messages.push(ChatMessage::tool(name, result));
+        }
+
+        if let Some(proposal) = pending_proposal {
+            push_trace(
+                &mut debug_trace,
+                "proposal tool used: stopping agent loop until user confirms in UI".into(),
+            );
+            return Ok(AgentChatResult {
+                messages,
+                assistant_reply: assistant_content,
+                steps_used,
+                debug_trace,
+                pending_proposal: Some(proposal),
+            });
         }
     }
 }
@@ -246,15 +271,9 @@ mod tests {
             },
         ]);
         let reg = ToolRegistry::with_echo_only();
-        let out = run_agent_loop(
-            &client,
-            "m",
-            vec![ChatMessage::user("hi")],
-            &reg,
-            8,
-        )
-        .await
-        .unwrap();
+        let out = run_agent_loop(&client, "m", vec![ChatMessage::user("hi")], &reg, 8)
+            .await
+            .unwrap();
 
         assert_eq!(out.assistant_reply, "done");
         assert_eq!(out.steps_used, 2);
@@ -274,15 +293,9 @@ mod tests {
             }],
         }]);
         let reg = ToolRegistry::with_echo_only();
-        let err = run_agent_loop(
-            &client,
-            "m",
-            vec![ChatMessage::user("hi")],
-            &reg,
-            1,
-        )
-        .await
-        .unwrap_err();
+        let err = run_agent_loop(&client, "m", vec![ChatMessage::user("hi")], &reg, 1)
+            .await
+            .unwrap_err();
         assert!(matches!(err, AgentError::MaxSteps { limit: 1 }));
     }
 
@@ -298,15 +311,9 @@ mod tests {
             }],
         }]);
         let reg = ToolRegistry::with_echo_only();
-        let err = run_agent_loop(
-            &client,
-            "m",
-            vec![ChatMessage::user("hi")],
-            &reg,
-            8,
-        )
-        .await
-        .unwrap_err();
+        let err = run_agent_loop(&client, "m", vec![ChatMessage::user("hi")], &reg, 8)
+            .await
+            .unwrap_err();
         assert!(matches!(err, AgentError::UnknownTool(_)));
     }
 
@@ -337,15 +344,9 @@ mod tests {
             },
         ]);
         let reg = ToolRegistry::with_echo_only();
-        let out = run_agent_loop(
-            &client,
-            "m",
-            vec![ChatMessage::user("hi")],
-            &reg,
-            8,
-        )
-        .await
-        .unwrap();
+        let out = run_agent_loop(&client, "m", vec![ChatMessage::user("hi")], &reg, 8)
+            .await
+            .unwrap();
 
         assert_eq!(out.assistant_reply, "done");
         assert!(out.messages.iter().any(|m| m.role == "tool"));
@@ -355,5 +356,35 @@ mod tests {
     #[test]
     fn reqwest_client_default() {
         let _ = ReqwestOllamaClient::default();
+    }
+
+    #[tokio::test]
+    async fn loop_stops_after_propose_tool_without_second_model_turn() {
+        let client = ScriptedClient::new(vec![AssistantTurn {
+            content: "I will delete that page.".into(),
+            tool_calls: vec![ToolCall {
+                function: ToolCallFunction {
+                    name: "propose_page_delete".into(),
+                    arguments: json!({ "page_id": "pid-1", "title": "Note A" }),
+                },
+            }],
+        }]);
+        let reg = ToolRegistry::with_propose_delete_only();
+        let out = run_agent_loop(
+            &client,
+            "m",
+            vec![ChatMessage::user("delete my page")],
+            &reg,
+            8,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(out.steps_used, 1);
+        let prop = out.pending_proposal.expect("pending proposal");
+        assert_eq!(prop.op, "delete");
+        assert_eq!(prop.page_id.as_deref(), Some("pid-1"));
+        assert_eq!(out.assistant_reply, "I will delete that page.");
+        assert_eq!(out.messages.last().unwrap().role, "tool");
     }
 }

--- a/src-tauri/src/agent/types.rs
+++ b/src-tauri/src/agent/types.rs
@@ -92,6 +92,32 @@ pub struct ToolFunctionDef {
     pub parameters: Value,
 }
 
+/// Structured page mutation proposed by the model; **not** applied until the user confirms in the UI.
+/// Serialized as the tool result string for `propose_page_*` tools and returned on [`AgentChatResult::pending_proposal`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PageProposal {
+    /// `"create"`, `"save"`, or `"delete"`.
+    pub op: String,
+    /// Target page id (required for save/delete).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+}
+
+/// Returns true for tools that record a proposal only (host stops the agent loop until the user acts in the UI).
+pub fn is_proposal_tool_name(name: &str) -> bool {
+    matches!(
+        name,
+        "propose_page_create" | "propose_page_save" | "propose_page_delete"
+    )
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentChatResult {
@@ -101,6 +127,9 @@ pub struct AgentChatResult {
     /// Human-readable lines for debugging tool usage (also logged with `log` in the agent loop).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub debug_trace: Vec<String>,
+    /// Set when the model used a `propose_page_*` tool: mutations run only after UI confirmation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_proposal: Option<PageProposal>,
 }
 
 #[cfg(test)]
@@ -143,10 +172,7 @@ mod tests {
             ]
         }"#;
         let m: ChatMessage = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            m.tool_calls.unwrap()[0].function.arguments["message"],
-            "x"
-        );
+        assert_eq!(m.tool_calls.unwrap()[0].function.arguments["message"], "x");
     }
 
     #[test]

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -4,11 +4,12 @@ use crate::agent::client::{chat_simple_user_message, create_chat_completion_clie
 use crate::agent::{run_agent_loop, AgentChatResult, ChatMessage, ToolRegistry};
 
 /// Reduces models imitating VS Code / Copilot / web search tool names that do not exist in this app.
-const AGENT_SYSTEM_PROMPT: &str = r#"You run inside the Lote app. The ONLY tools you may use are exactly those provided by the host: `echo` and `search_pages`.
+const AGENT_SYSTEM_PROMPT: &str = r#"You run inside the Lote app. The ONLY tools you may use are exactly those provided by the host: `echo`, `search_pages`, `propose_page_create`, `propose_page_save`, and `propose_page_delete`.
 
-- To search the user's local markdown notes or pages, you MUST call `search_pages` with a `query` string. Do not invent tool names (no vscode, copilot, websearch, google, or browser tools—they are not available).
-- Do not paste fake tool JSON in markdown. Use the API's native tool-calling mechanism so the host can run `search_pages`.
-- You cannot search the public web; only local pages via `search_pages`."#;
+- To search the user's local markdown notes or pages, call `search_pages` with a `query` string. You cannot search the public web.
+- To create, update, or delete pages, you MUST use the `propose_page_*` tools only. Those tools record what you want to do; the host does NOT apply changes until the user explicitly confirms in the UI. Never claim a page was created, saved, or deleted until after the user has confirmed (you will not see confirmation in-chat).
+- Do not invent other tool names (no vscode, copilot, websearch, google, or browser tools).
+- Prefer native tool-calling for `search_pages` and `propose_page_*`; do not paste fake tool JSON in markdown unless the host supports it."#;
 
 /// Provider-neutral non-streaming chat command.
 #[tauri::command]

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -7,6 +7,11 @@ declare global {
     // interface PageData {}
     // interface PageState {}
   }
+
+  interface Window {
+    /** Set only when built with `VITE_E2E_CAPTURE=true` (desktop PR capture). */
+    __loteSeedAgentDemo?: (scenario: 'create' | 'save' | 'delete') => void
+  }
 }
 
 export {}

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -10,7 +10,7 @@ declare global {
 
   interface Window {
     /** Set only when built with `VITE_E2E_CAPTURE=true` (desktop PR capture). */
-    __loteSeedAgentDemo?: (scenario: 'create' | 'save' | 'delete') => void
+    __loteSeedAgentDemo?: (scenario: 'create' | 'save' | 'delete') => Promise<void>
   }
 }
 

--- a/src/components/action-button/action-button.svelte
+++ b/src/components/action-button/action-button.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte'
 
-  type Variant = 'default' | 'primary' | 'danger'
+  type Variant = 'default' | 'primary' | 'danger' | 'approve' | 'outline'
 
   let {
     variant = 'default',
@@ -23,11 +23,13 @@
   } = $props()
 
   const base = $derived(
-    variant === 'primary'
+    variant === 'primary' || variant === 'approve'
       ? 'rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-500 disabled:opacity-40'
       : variant === 'danger'
         ? 'rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-700 hover:bg-red-100 disabled:opacity-40'
-        : 'rounded-md border border-zinc-200 bg-zinc-100 px-2 py-1 text-xs text-zinc-800 hover:bg-zinc-200 disabled:opacity-40',
+        : variant === 'outline'
+          ? 'rounded-md border border-zinc-300 bg-white px-2 py-1 text-xs font-medium text-zinc-800 hover:bg-zinc-50 disabled:opacity-40'
+          : 'rounded-md border border-zinc-200 bg-zinc-100 px-2 py-1 text-xs text-zinc-800 hover:bg-zinc-200 disabled:opacity-40',
   )
 </script>
 

--- a/src/components/chat-proposal-approval/chat-proposal-approval.svelte
+++ b/src/components/chat-proposal-approval/chat-proposal-approval.svelte
@@ -104,17 +104,21 @@
           {#each bodyRows as row, ri (ri)}
             {#if row.type === 'collapsed'}
               <div
-                class="flex min-h-[1.25rem] border-b border-sky-200/80 bg-sky-100/90 last:border-b-0"
+                class="border-b border-zinc-100 bg-white py-1.5 last:border-b-0"
                 data-testid="chat-proposal-body-collapsed"
                 role="presentation"
                 title="{row.omittedCount ?? 0} unchanged lines omitted"
               >
-                <span class="w-4 shrink-0 select-none px-1 text-center text-sky-500"></span>
-                <span
-                  class="min-w-0 flex-1 py-0.5 pr-1 text-center text-[10px] font-medium text-sky-800"
+                <div
+                  class="flex min-h-[1.25rem] rounded border border-sky-200/80 bg-sky-100/90"
                 >
-                  省略
-                </span>
+                  <span class="w-4 shrink-0 select-none px-1 text-center text-sky-500"></span>
+                  <span
+                    class="min-w-0 flex-1 py-0.5 pr-1 text-center text-[10px] font-medium text-sky-800"
+                  >
+                    省略
+                  </span>
+                </div>
               </div>
             {:else}
               <div

--- a/src/components/chat-proposal-approval/chat-proposal-approval.svelte
+++ b/src/components/chat-proposal-approval/chat-proposal-approval.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { ProposalPreview } from '$lib/proposal-preview'
-  import { diffBodyToRows } from '$lib/proposal-preview'
+  import { diffBodyToProposalRows } from '$lib/proposal-preview'
 
   import ActionButton from '../action-button'
 
@@ -28,7 +28,7 @@
 
   const bodyRows = $derived(
     preview.kind === 'save' && bodyDiff
-      ? diffBodyToRows(preview.before.body, preview.after.body)
+      ? diffBodyToProposalRows(preview.before.body, preview.after.body)
       : [],
   )
 
@@ -102,24 +102,40 @@
           class="mt-0.5 max-h-[280px] overflow-y-auto rounded border border-zinc-200 font-mono text-[10px] leading-snug"
         >
           {#each bodyRows as row, ri (ri)}
-            <div
-              class="flex min-h-[1.25rem] border-b border-zinc-100 last:border-b-0 {row.type === 'remove'
-                ? 'bg-red-50 text-red-950'
-                : row.type === 'add'
-                  ? 'bg-green-50 text-green-950'
-                  : 'bg-white text-zinc-700'}"
-            >
-              <span
-                class="w-4 shrink-0 select-none px-1 text-center {row.type === 'remove'
-                  ? 'text-red-600'
-                  : row.type === 'add'
-                    ? 'text-green-700'
-                    : 'text-zinc-400'}"
+            {#if row.type === 'collapsed'}
+              <div
+                class="flex min-h-[1.25rem] border-b border-sky-200/80 bg-sky-100/90 last:border-b-0"
+                data-testid="chat-proposal-body-collapsed"
+                role="presentation"
+                title="{row.omittedCount ?? 0} unchanged lines omitted"
               >
-                {row.type === 'remove' ? '-' : row.type === 'add' ? '+' : ' '}
-              </span>
-              <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-1">{row.text || ' '}</span>
-            </div>
+                <span class="w-4 shrink-0 select-none px-1 text-center text-sky-500"></span>
+                <span
+                  class="min-w-0 flex-1 py-0.5 pr-1 text-center text-[10px] font-medium text-sky-800"
+                >
+                  省略
+                </span>
+              </div>
+            {:else}
+              <div
+                class="flex min-h-[1.25rem] border-b border-zinc-100 last:border-b-0 {row.type === 'remove'
+                  ? 'bg-red-50 text-red-950'
+                  : row.type === 'add'
+                    ? 'bg-green-50 text-green-950'
+                    : 'bg-white text-zinc-700'}"
+              >
+                <span
+                  class="w-4 shrink-0 select-none px-1 text-center {row.type === 'remove'
+                    ? 'text-red-600'
+                    : row.type === 'add'
+                      ? 'text-green-700'
+                      : 'text-zinc-400'}"
+                >
+                  {row.type === 'remove' ? '-' : row.type === 'add' ? '+' : ' '}
+                </span>
+                <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-1">{row.text || ' '}</span>
+              </div>
+            {/if}
           {/each}
         </div>
       {/if}

--- a/src/components/chat-proposal-approval/chat-proposal-approval.svelte
+++ b/src/components/chat-proposal-approval/chat-proposal-approval.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { ProposalPreview } from '$lib/proposal-preview'
-  import { compareBodyLines } from '$lib/proposal-preview'
 
   import ActionButton from '../action-button'
 
@@ -16,15 +15,18 @@
     onCancel: () => void
   } = $props()
 
-  const bodyRows = $derived(
-    preview.kind === 'save' ? compareBodyLines(preview.before.body, preview.after.body) : [],
-  )
-
   const titleDiff = $derived(
     preview.kind === 'save' ? preview.before.title !== preview.after.title : false,
   )
   const parentDiff = $derived(
     preview.kind === 'save' ? preview.before.parentLabel !== preview.after.parentLabel : false,
+  )
+  const bodyDiff = $derived(
+    preview.kind === 'save' ? preview.before.body !== preview.after.body : false,
+  )
+
+  const saveHasAnyChange = $derived(
+    preview.kind === 'save' ? titleDiff || parentDiff || bodyDiff : false,
   )
 </script>
 
@@ -42,97 +44,70 @@
     <p class="mt-1 text-[10px] text-zinc-500">Cancel to keep the page, or Approve to delete it.</p>
   {:else if preview.kind === 'create'}
     <p class="text-[11px] font-semibold text-zinc-900">Create new page</p>
-    <div class="mt-2 grid grid-cols-2 gap-2 text-[10px]">
-      <div>
-        <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Before</p>
-        <div class="rounded border border-zinc-200 bg-white p-2 text-zinc-600">
-          {preview.beforeSummary}
-        </div>
-      </div>
-      <div>
-        <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">After</p>
-        <div class="rounded border border-emerald-200 bg-green-50/80 p-2 text-zinc-800">
-          <p><span class="text-zinc-500">Title:</span> {preview.afterTitle}</p>
-          <p class="mt-1"><span class="text-zinc-500">Parent:</span> {preview.afterParentLabel}</p>
-        </div>
-      </div>
+
+    <p class="mt-3 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">Before</p>
+    <div
+      class="mt-1 rounded border border-zinc-300 bg-white px-2.5 py-2 text-[10px] leading-relaxed text-zinc-600"
+    >
+      {preview.beforeSummary}
+    </div>
+
+    <p class="mt-3 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">After</p>
+    <div
+      class="mt-1 rounded border border-emerald-200 bg-green-50/80 px-2.5 py-2 text-[10px] leading-relaxed text-zinc-800"
+    >
+      <p><span class="text-zinc-500">Title:</span> {preview.afterTitle}</p>
+      <p class="mt-1.5"><span class="text-zinc-500">Parent:</span> {preview.afterParentLabel}</p>
     </div>
   {:else}
     <p class="text-[11px] font-semibold text-zinc-900">Save changes to page</p>
-    <p class="mt-1 text-[10px] text-zinc-500">Compare before and after. Changed lines are highlighted.</p>
-    <div class="mt-2 space-y-2 text-[10px]">
-      <div class="grid grid-cols-2 gap-2">
-        <div>
-          <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Before</p>
-          <div
-            class="rounded border border-zinc-200 p-1.5 {titleDiff
-              ? 'bg-red-50/90'
-              : 'bg-white'}"
-          >
-            {preview.before.title}
-          </div>
-        </div>
-        <div>
-          <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">After</p>
-          <div
-            class="rounded border border-zinc-200 p-1.5 {titleDiff
-              ? 'bg-green-50/90'
-              : 'bg-white'}"
-          >
-            {preview.after.title}
-          </div>
-        </div>
-      </div>
-      <div class="grid grid-cols-2 gap-2">
-        <div>
-          <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Parent</p>
-          <div
-            class="rounded border border-zinc-200 p-1.5 {parentDiff
-              ? 'bg-red-50/90'
-              : 'bg-white'}"
-          >
+    <p class="mt-1 text-[10px] text-zinc-500">Review what will change. Unchanged title or parent are hidden.</p>
+
+    {#if saveHasAnyChange}
+      <p class="mt-3 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">Before</p>
+      <div
+        class="mt-1 rounded border border-zinc-300 bg-white px-2.5 py-2 text-[10px] leading-relaxed text-zinc-800"
+      >
+        {#if titleDiff}
+          <p><span class="text-zinc-500">Title:</span> {preview.before.title}</p>
+        {/if}
+        {#if parentDiff}
+          <p class={titleDiff ? 'mt-1.5' : ''}>
+            <span class="text-zinc-500">Parent:</span>
             {preview.before.parentLabel}
+          </p>
+        {/if}
+        {#if bodyDiff}
+          <div class="{titleDiff || parentDiff ? 'mt-2 border-t border-zinc-200 pt-2' : ''}">
+            <pre class="whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-zinc-800">{preview
+              .before.body}</pre>
           </div>
-        </div>
-        <div>
-          <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Parent</p>
-          <div
-            class="rounded border border-zinc-200 p-1.5 {parentDiff
-              ? 'bg-green-50/90'
-              : 'bg-white'}"
-          >
+        {/if}
+      </div>
+
+      <p class="mt-3 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">After</p>
+      <div
+        class="mt-1 rounded border border-emerald-200 bg-green-50/80 px-2.5 py-2 text-[10px] leading-relaxed text-zinc-800"
+      >
+        {#if titleDiff}
+          <p><span class="text-zinc-500">Title:</span> {preview.after.title}</p>
+        {/if}
+        {#if parentDiff}
+          <p class={titleDiff ? 'mt-1.5' : ''}>
+            <span class="text-zinc-500">Parent:</span>
             {preview.after.parentLabel}
+          </p>
+        {/if}
+        {#if bodyDiff}
+          <div class="{titleDiff || parentDiff ? 'mt-2 border-t border-zinc-200 pt-2' : ''}">
+            <pre class="whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-zinc-800">{preview
+              .after.body}</pre>
           </div>
-        </div>
+        {/if}
       </div>
-      <div>
-        <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Body</p>
-        <div class="grid max-h-48 grid-cols-2 gap-1 overflow-y-auto rounded border border-zinc-200">
-          <div class="border-r border-zinc-200 bg-white">
-            {#each bodyRows as row, ri (ri)}
-              <div
-                class="whitespace-pre-wrap break-words border-b border-zinc-100 px-1.5 py-0.5 font-mono leading-snug {row.unchanged
-                  ? 'bg-white text-zinc-700'
-                  : 'bg-red-50/90 text-zinc-900'}"
-              >
-                {row.beforeLine || ' '}
-              </div>
-            {/each}
-          </div>
-          <div class="bg-white">
-            {#each bodyRows as row, ri (ri)}
-              <div
-                class="whitespace-pre-wrap break-words border-b border-zinc-100 px-1.5 py-0.5 font-mono leading-snug {row.unchanged
-                  ? 'bg-white text-zinc-700'
-                  : 'bg-green-50/90 text-zinc-900'}"
-              >
-                {row.afterLine || ' '}
-              </div>
-            {/each}
-          </div>
-        </div>
-      </div>
-    </div>
+    {:else}
+      <p class="mt-2 text-[10px] text-zinc-500">No field changes detected in this proposal.</p>
+    {/if}
   {/if}
 
   <div class="mt-3 flex justify-end gap-2">

--- a/src/components/chat-proposal-approval/chat-proposal-approval.svelte
+++ b/src/components/chat-proposal-approval/chat-proposal-approval.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ProposalPreview } from '$lib/proposal-preview'
+  import { diffBodyToRows } from '$lib/proposal-preview'
 
   import ActionButton from '../action-button'
 
@@ -25,6 +26,12 @@
     preview.kind === 'save' ? preview.before.body !== preview.after.body : false,
   )
 
+  const bodyRows = $derived(
+    preview.kind === 'save' && bodyDiff
+      ? diffBodyToRows(preview.before.body, preview.after.body)
+      : [],
+  )
+
   const saveHasAnyChange = $derived(
     preview.kind === 'save' ? titleDiff || parentDiff || bodyDiff : false,
   )
@@ -43,68 +50,79 @@
     </p>
     <p class="mt-1 text-[10px] text-zinc-500">Cancel to keep the page, or Approve to delete it.</p>
   {:else if preview.kind === 'create'}
-    <p class="text-[11px] font-semibold text-zinc-900">Create new page</p>
-
-    <p class="mt-3 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">Before</p>
+    <p class="text-[11px] font-semibold text-zinc-900">New page</p>
+    <p class="mt-1 text-[10px] text-zinc-600">The following page will be created:</p>
     <div
-      class="mt-1 rounded border border-zinc-300 bg-white px-2.5 py-2 text-[10px] leading-relaxed text-zinc-600"
-    >
-      {preview.beforeSummary}
-    </div>
-
-    <p class="mt-3 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">After</p>
-    <div
-      class="mt-1 rounded border border-emerald-200 bg-green-50/80 px-2.5 py-2 text-[10px] leading-relaxed text-zinc-800"
+      class="mt-2 rounded border border-zinc-300 bg-white px-2.5 py-2 text-[10px] leading-relaxed text-zinc-800"
     >
       <p><span class="text-zinc-500">Title:</span> {preview.afterTitle}</p>
       <p class="mt-1.5"><span class="text-zinc-500">Parent:</span> {preview.afterParentLabel}</p>
     </div>
   {:else}
     <p class="text-[11px] font-semibold text-zinc-900">Save changes to page</p>
-    <p class="mt-1 text-[10px] text-zinc-500">Review what will change. Unchanged title or parent are hidden.</p>
+    <p class="mt-1 text-[10px] text-zinc-500">
+      Red = removed, green = added. Title and parent appear only if they change.
+    </p>
 
     {#if saveHasAnyChange}
-      <p class="mt-3 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">Before</p>
-      <div
-        class="mt-1 rounded border border-zinc-300 bg-white px-2.5 py-2 text-[10px] leading-relaxed text-zinc-800"
-      >
-        {#if titleDiff}
-          <p><span class="text-zinc-500">Title:</span> {preview.before.title}</p>
-        {/if}
-        {#if parentDiff}
-          <p class={titleDiff ? 'mt-1.5' : ''}>
-            <span class="text-zinc-500">Parent:</span>
-            {preview.before.parentLabel}
-          </p>
-        {/if}
-        {#if bodyDiff}
-          <div class="{titleDiff || parentDiff ? 'mt-2 border-t border-zinc-200 pt-2' : ''}">
-            <pre class="whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-zinc-800">{preview
-              .before.body}</pre>
+      {#if titleDiff}
+        <p class="mt-2 text-[10px] font-medium text-zinc-600">Title</p>
+        <div class="mt-0.5 overflow-hidden rounded border border-zinc-200 font-mono text-[10px] leading-snug">
+          <div class="flex bg-red-50 text-red-900">
+            <span class="w-4 shrink-0 select-none px-1 text-center text-red-600">-</span>
+            <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-1">{preview.before
+                .title}</span>
           </div>
-        {/if}
-      </div>
+          <div class="flex border-t border-zinc-100 bg-green-50 text-green-900">
+            <span class="w-4 shrink-0 select-none px-1 text-center text-green-700">+</span>
+            <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-1">{preview.after.title}</span>
+          </div>
+        </div>
+      {/if}
 
-      <p class="mt-3 text-[10px] font-semibold uppercase tracking-wide text-zinc-500">After</p>
-      <div
-        class="mt-1 rounded border border-emerald-200 bg-green-50/80 px-2.5 py-2 text-[10px] leading-relaxed text-zinc-800"
-      >
-        {#if titleDiff}
-          <p><span class="text-zinc-500">Title:</span> {preview.after.title}</p>
-        {/if}
-        {#if parentDiff}
-          <p class={titleDiff ? 'mt-1.5' : ''}>
-            <span class="text-zinc-500">Parent:</span>
-            {preview.after.parentLabel}
-          </p>
-        {/if}
-        {#if bodyDiff}
-          <div class="{titleDiff || parentDiff ? 'mt-2 border-t border-zinc-200 pt-2' : ''}">
-            <pre class="whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-zinc-800">{preview
-              .after.body}</pre>
+      {#if parentDiff}
+        <p class="mt-2 text-[10px] font-medium text-zinc-600">Parent</p>
+        <div class="mt-0.5 overflow-hidden rounded border border-zinc-200 font-mono text-[10px] leading-snug">
+          <div class="flex bg-red-50 text-red-900">
+            <span class="w-4 shrink-0 select-none px-1 text-center text-red-600">-</span>
+            <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-1">{preview.before
+                .parentLabel}</span>
           </div>
-        {/if}
-      </div>
+          <div class="flex border-t border-zinc-100 bg-green-50 text-green-900">
+            <span class="w-4 shrink-0 select-none px-1 text-center text-green-700">+</span>
+            <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-1">{preview.after
+                .parentLabel}</span>
+          </div>
+        </div>
+      {/if}
+
+      {#if bodyDiff}
+        <p class="mt-2 text-[10px] font-medium text-zinc-600">Body</p>
+        <div
+          class="mt-0.5 max-h-[280px] overflow-y-auto rounded border border-zinc-200 font-mono text-[10px] leading-snug"
+        >
+          {#each bodyRows as row, ri (ri)}
+            <div
+              class="flex min-h-[1.25rem] border-b border-zinc-100 last:border-b-0 {row.type === 'remove'
+                ? 'bg-red-50 text-red-950'
+                : row.type === 'add'
+                  ? 'bg-green-50 text-green-950'
+                  : 'bg-white text-zinc-700'}"
+            >
+              <span
+                class="w-4 shrink-0 select-none px-1 text-center {row.type === 'remove'
+                  ? 'text-red-600'
+                  : row.type === 'add'
+                    ? 'text-green-700'
+                    : 'text-zinc-400'}"
+              >
+                {row.type === 'remove' ? '-' : row.type === 'add' ? '+' : ' '}
+              </span>
+              <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-1">{row.text || ' '}</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
     {:else}
       <p class="mt-2 text-[10px] text-zinc-500">No field changes detected in this proposal.</p>
     {/if}

--- a/src/components/chat-proposal-approval/chat-proposal-approval.svelte
+++ b/src/components/chat-proposal-approval/chat-proposal-approval.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { ProposalPreview } from '$lib/proposal-preview'
-  import { diffBodyToRows } from '$lib/proposal-preview'
+  import { diffBodyToGutterRows } from '$lib/proposal-preview'
 
   import ActionButton from '../action-button'
 
@@ -28,7 +28,7 @@
 
   const bodyRows = $derived(
     preview.kind === 'save' && bodyDiff
-      ? diffBodyToRows(preview.before.body, preview.after.body)
+      ? diffBodyToGutterRows(preview.before.body, preview.after.body)
       : [],
   )
 
@@ -106,19 +106,28 @@
               class="flex min-h-[1.25rem] border-b border-zinc-100 last:border-b-0 {row.type === 'remove'
                 ? 'bg-red-50 text-red-950'
                 : row.type === 'add'
-                  ? 'bg-green-50 text-green-950'
-                  : 'bg-white text-zinc-700'}"
+                  ? 'bg-emerald-50/90 text-emerald-950'
+                  : 'bg-white text-zinc-800'}"
             >
               <span
-                class="w-4 shrink-0 select-none px-1 text-center {row.type === 'remove'
+                class="w-9 shrink-0 select-none border-r border-zinc-200/80 py-0.5 pl-1 pr-1 text-right tabular-nums text-zinc-400"
+                >{row.oldLine ?? ''}</span
+              >
+              <span
+                class="w-9 shrink-0 select-none border-r border-zinc-200/80 py-0.5 pl-1 pr-1 text-right tabular-nums text-zinc-400"
+                >{row.newLine ?? ''}</span
+              >
+              <span
+                class="w-5 shrink-0 select-none border-r border-zinc-200/80 py-0.5 pl-0.5 text-center tabular-nums {row.type ===
+                'remove'
                   ? 'text-red-600'
                   : row.type === 'add'
-                    ? 'text-green-700'
-                    : 'text-zinc-400'}"
+                    ? 'text-emerald-700'
+                    : 'text-zinc-300'}"
               >
                 {row.type === 'remove' ? '-' : row.type === 'add' ? '+' : ' '}
               </span>
-              <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-1">{row.text || ' '}</span>
+              <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-2 pl-1">{row.text || ' '}</span>
             </div>
           {/each}
         </div>

--- a/src/components/chat-proposal-approval/chat-proposal-approval.svelte
+++ b/src/components/chat-proposal-approval/chat-proposal-approval.svelte
@@ -97,7 +97,7 @@
       {/if}
 
       {#if bodyDiff}
-        <p class="mt-2 text-[10px] font-medium text-zinc-600">Body</p>
+        <p class="mt-2 text-[10px] font-medium text-zinc-600">Content</p>
         <div
           class="mt-0.5 max-h-[280px] overflow-y-auto rounded border border-zinc-200 font-mono text-[10px] leading-snug"
         >

--- a/src/components/chat-proposal-approval/chat-proposal-approval.svelte
+++ b/src/components/chat-proposal-approval/chat-proposal-approval.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import type { ProposalPreview } from '$lib/proposal-preview'
+  import { compareBodyLines } from '$lib/proposal-preview'
+
+  import ActionButton from '../action-button'
+
+  let {
+    preview,
+    busy,
+    onApprove,
+    onCancel,
+  }: {
+    preview: ProposalPreview
+    busy: boolean
+    onApprove: () => void
+    onCancel: () => void
+  } = $props()
+
+  const bodyRows = $derived(
+    preview.kind === 'save' ? compareBodyLines(preview.before.body, preview.after.body) : [],
+  )
+
+  const titleDiff = $derived(
+    preview.kind === 'save' ? preview.before.title !== preview.after.title : false,
+  )
+  const parentDiff = $derived(
+    preview.kind === 'save' ? preview.before.parentLabel !== preview.after.parentLabel : false,
+  )
+</script>
+
+<div
+  class="mb-2 rounded-md border border-zinc-200 bg-zinc-50/95 p-2.5 shadow-sm"
+  role="region"
+  aria-label="Review proposed change"
+  data-testid="chat-proposal-panel"
+>
+  {#if preview.kind === 'delete'}
+    <p class="text-[11px] font-semibold text-zinc-900">Delete page</p>
+    <p class="mt-2 text-[11px] leading-snug text-zinc-800">
+      Permanently delete <span class="font-semibold">“{preview.pageTitle}”</span>? This cannot be undone.
+    </p>
+    <p class="mt-1 text-[10px] text-zinc-500">Cancel to keep the page, or Approve to delete it.</p>
+  {:else if preview.kind === 'create'}
+    <p class="text-[11px] font-semibold text-zinc-900">Create new page</p>
+    <div class="mt-2 grid grid-cols-2 gap-2 text-[10px]">
+      <div>
+        <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Before</p>
+        <div class="rounded border border-zinc-200 bg-white p-2 text-zinc-600">
+          {preview.beforeSummary}
+        </div>
+      </div>
+      <div>
+        <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">After</p>
+        <div class="rounded border border-emerald-200 bg-green-50/80 p-2 text-zinc-800">
+          <p><span class="text-zinc-500">Title:</span> {preview.afterTitle}</p>
+          <p class="mt-1"><span class="text-zinc-500">Parent:</span> {preview.afterParentLabel}</p>
+        </div>
+      </div>
+    </div>
+  {:else}
+    <p class="text-[11px] font-semibold text-zinc-900">Save changes to page</p>
+    <p class="mt-1 text-[10px] text-zinc-500">Compare before and after. Changed lines are highlighted.</p>
+    <div class="mt-2 space-y-2 text-[10px]">
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Before</p>
+          <div
+            class="rounded border border-zinc-200 p-1.5 {titleDiff
+              ? 'bg-red-50/90'
+              : 'bg-white'}"
+          >
+            {preview.before.title}
+          </div>
+        </div>
+        <div>
+          <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">After</p>
+          <div
+            class="rounded border border-zinc-200 p-1.5 {titleDiff
+              ? 'bg-green-50/90'
+              : 'bg-white'}"
+          >
+            {preview.after.title}
+          </div>
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Parent</p>
+          <div
+            class="rounded border border-zinc-200 p-1.5 {parentDiff
+              ? 'bg-red-50/90'
+              : 'bg-white'}"
+          >
+            {preview.before.parentLabel}
+          </div>
+        </div>
+        <div>
+          <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Parent</p>
+          <div
+            class="rounded border border-zinc-200 p-1.5 {parentDiff
+              ? 'bg-green-50/90'
+              : 'bg-white'}"
+          >
+            {preview.after.parentLabel}
+          </div>
+        </div>
+      </div>
+      <div>
+        <p class="mb-0.5 font-medium uppercase tracking-wide text-zinc-500">Body</p>
+        <div class="grid max-h-48 grid-cols-2 gap-1 overflow-y-auto rounded border border-zinc-200">
+          <div class="border-r border-zinc-200 bg-white">
+            {#each bodyRows as row, ri (ri)}
+              <div
+                class="whitespace-pre-wrap break-words border-b border-zinc-100 px-1.5 py-0.5 font-mono leading-snug {row.unchanged
+                  ? 'bg-white text-zinc-700'
+                  : 'bg-red-50/90 text-zinc-900'}"
+              >
+                {row.beforeLine || ' '}
+              </div>
+            {/each}
+          </div>
+          <div class="bg-white">
+            {#each bodyRows as row, ri (ri)}
+              <div
+                class="whitespace-pre-wrap break-words border-b border-zinc-100 px-1.5 py-0.5 font-mono leading-snug {row.unchanged
+                  ? 'bg-white text-zinc-700'
+                  : 'bg-green-50/90 text-zinc-900'}"
+              >
+                {row.afterLine || ' '}
+              </div>
+            {/each}
+          </div>
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <div class="mt-3 flex justify-end gap-2">
+    <ActionButton variant="outline" disabled={busy} dataTestId="chat-proposal-cancel" onclick={onCancel}>
+      Cancel
+    </ActionButton>
+    <ActionButton variant="approve" disabled={busy} dataTestId="chat-proposal-approve" onclick={onApprove}>
+      Approve
+    </ActionButton>
+  </div>
+</div>

--- a/src/components/chat-proposal-approval/chat-proposal-approval.svelte
+++ b/src/components/chat-proposal-approval/chat-proposal-approval.svelte
@@ -116,7 +116,7 @@
                   <span
                     class="min-w-0 flex-1 py-0.5 pr-1 text-center text-[10px] font-medium text-sky-800"
                   >
-                    省略
+                    Omitted
                   </span>
                 </div>
               </div>

--- a/src/components/chat-proposal-approval/chat-proposal-approval.svelte
+++ b/src/components/chat-proposal-approval/chat-proposal-approval.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { ProposalPreview } from '$lib/proposal-preview'
-  import { diffBodyToGutterRows } from '$lib/proposal-preview'
+  import { diffBodyToRows } from '$lib/proposal-preview'
 
   import ActionButton from '../action-button'
 
@@ -28,7 +28,7 @@
 
   const bodyRows = $derived(
     preview.kind === 'save' && bodyDiff
-      ? diffBodyToGutterRows(preview.before.body, preview.after.body)
+      ? diffBodyToRows(preview.before.body, preview.after.body)
       : [],
   )
 
@@ -106,28 +106,19 @@
               class="flex min-h-[1.25rem] border-b border-zinc-100 last:border-b-0 {row.type === 'remove'
                 ? 'bg-red-50 text-red-950'
                 : row.type === 'add'
-                  ? 'bg-emerald-50/90 text-emerald-950'
-                  : 'bg-white text-zinc-800'}"
+                  ? 'bg-green-50 text-green-950'
+                  : 'bg-white text-zinc-700'}"
             >
               <span
-                class="w-9 shrink-0 select-none border-r border-zinc-200/80 py-0.5 pl-1 pr-1 text-right tabular-nums text-zinc-400"
-                >{row.oldLine ?? ''}</span
-              >
-              <span
-                class="w-9 shrink-0 select-none border-r border-zinc-200/80 py-0.5 pl-1 pr-1 text-right tabular-nums text-zinc-400"
-                >{row.newLine ?? ''}</span
-              >
-              <span
-                class="w-5 shrink-0 select-none border-r border-zinc-200/80 py-0.5 pl-0.5 text-center tabular-nums {row.type ===
-                'remove'
+                class="w-4 shrink-0 select-none px-1 text-center {row.type === 'remove'
                   ? 'text-red-600'
                   : row.type === 'add'
-                    ? 'text-emerald-700'
-                    : 'text-zinc-300'}"
+                    ? 'text-green-700'
+                    : 'text-zinc-400'}"
               >
                 {row.type === 'remove' ? '-' : row.type === 'add' ? '+' : ' '}
               </span>
-              <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-2 pl-1">{row.text || ' '}</span>
+              <span class="min-w-0 flex-1 whitespace-pre-wrap break-words py-0.5 pr-1">{row.text || ' '}</span>
             </div>
           {/each}
         </div>

--- a/src/components/text-area/text-area.svelte
+++ b/src/components/text-area/text-area.svelte
@@ -4,11 +4,13 @@
     placeholder = '',
     plain = false,
     class: className = '',
+    dataTestId = undefined,
   }: {
     value?: string
     placeholder?: string
     plain?: boolean
     class?: string
+    dataTestId?: string
   } = $props()
 
   const base = $derived(
@@ -18,4 +20,9 @@
   )
 </script>
 
-<textarea class="{base} {className}" bind:value {placeholder}></textarea>
+<textarea
+  class="{base} {className}"
+  data-testid={dataTestId}
+  bind:value
+  {placeholder}
+></textarea>

--- a/src/lib/e2e-long-doc-fixture.ts
+++ b/src/lib/e2e-long-doc-fixture.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared long-document strings for desktop E2E capture (PR screenshots).
+ * Keep in sync with `e2e-tauri/specs/desktop-capture.e2e.js` (Node cannot import this file).
+ */
+
+/** 100 lines of placeholder; first 4 and last 3 lines differ in {@link e2eLongDocAfter}. */
+export function e2eLongDocBefore(): string {
+  const lines: string[] = []
+  for (let i = 1; i <= 100; i++) {
+    lines.push(
+      `Line ${i}: Lorem ipsum dolor sit amet, placeholder content for capture demo.`,
+    )
+  }
+  return lines.join('\n')
+}
+
+export function e2eLongDocAfter(): string {
+  const lines = e2eLongDocBefore().split('\n')
+  for (let i = 0; i < 4; i++) {
+    lines[i] =
+      `Line ${i + 1} [EDITED]: Changed opening section for PR screenshot demo.`
+  }
+  for (let j = 0; j < 3; j++) {
+    const idx = 97 + j
+    lines[idx] =
+      `Line ${idx + 1} [EDITED]: Changed closing section for PR screenshot demo.`
+  }
+  return lines.join('\n')
+}

--- a/src/lib/lote-app-e2e-seed.test.ts
+++ b/src/lib/lote-app-e2e-seed.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildE2eAgentDemo } from './lote-app-e2e-seed'
+
+describe('buildE2eAgentDemo', () => {
+  it('returns create pack without a selected page', () => {
+    const p = buildE2eAgentDemo('create', null, '')
+    expect(p?.proposal.op).toBe('create')
+    expect(p?.messages.some((m) => m.role === 'user')).toBe(true)
+  })
+
+  it('returns null for save when no page is selected', () => {
+    expect(buildE2eAgentDemo('save', null, '')).toBeNull()
+  })
+
+  it('returns save pack when a page id is provided', () => {
+    const p = buildE2eAgentDemo('save', 'abc', 'T')
+    expect(p?.proposal.op).toBe('save')
+    expect(p?.proposal.pageId).toBe('abc')
+  })
+})

--- a/src/lib/lote-app-e2e-seed.ts
+++ b/src/lib/lote-app-e2e-seed.ts
@@ -1,3 +1,5 @@
+import { e2eLongDocAfter } from '$lib/e2e-long-doc-fixture'
+
 /** Shapes mirror `lote-app.svelte.ts` (avoid importing `.svelte.ts` from here). */
 export type E2eChatMsg = {
   role: string
@@ -61,8 +63,9 @@ function buildCreate(): E2eDemoPack {
 }
 
 function buildSave(selectedId: string): E2eDemoPack {
-  const nextTitle = `${E2E_AGENT_DEMO_TITLE} (edited)`
-  const nextBody = 'Edited body after AI save proposal.'
+  /** Same title as created page so the diff focuses on content only. */
+  const nextTitle = E2E_AGENT_DEMO_TITLE
+  const nextBody = e2eLongDocAfter()
   const toolContent = JSON.stringify({
     op: 'save',
     pageId: selectedId,
@@ -72,7 +75,10 @@ function buildSave(selectedId: string): E2eDemoPack {
   })
   return {
     messages: [
-      { role: 'user', content: 'Rename this page and update the body text.' },
+      {
+        role: 'user',
+        content: 'Update the opening and closing lines of the long document.',
+      },
       {
         role: 'assistant',
         content: 'Here is a proposed save. Confirm to apply.',

--- a/src/lib/lote-app-e2e-seed.ts
+++ b/src/lib/lote-app-e2e-seed.ts
@@ -1,0 +1,144 @@
+/** Shapes mirror `lote-app.svelte.ts` (avoid importing `.svelte.ts` from here). */
+export type E2eChatMsg = {
+  role: string
+  content?: string
+  tool_calls?: { function: { name: string; arguments: unknown } }[]
+  tool_name?: string
+}
+
+export type E2ePageProposal = {
+  op: 'create' | 'save' | 'delete'
+  pageId?: string
+  title?: string
+  parentId?: string | null
+  body?: string
+}
+
+export type E2eDemoPack = {
+  messages: E2eChatMsg[]
+  proposal: E2ePageProposal
+}
+
+const E2E_AGENT_DEMO_TITLE = 'PR Demo Page'
+
+function buildCreate(): E2eDemoPack {
+  const toolContent = JSON.stringify({
+    op: 'create',
+    title: E2E_AGENT_DEMO_TITLE,
+    parentId: null,
+  })
+  return {
+    messages: [
+      {
+        role: 'user',
+        content: `Create a new page titled "${E2E_AGENT_DEMO_TITLE}".`,
+      },
+      {
+        role: 'assistant',
+        content:
+          'I will propose creating that page. Please confirm below to create it in your library.',
+        tool_calls: [
+          {
+            function: {
+              name: 'propose_page_create',
+              arguments: { title: E2E_AGENT_DEMO_TITLE },
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        tool_name: 'propose_page_create',
+        content: toolContent,
+      },
+    ],
+    proposal: {
+      op: 'create',
+      title: E2E_AGENT_DEMO_TITLE,
+      parentId: null,
+    },
+  }
+}
+
+function buildSave(selectedId: string): E2eDemoPack {
+  const nextTitle = `${E2E_AGENT_DEMO_TITLE} (edited)`
+  const nextBody = 'Edited body after AI save proposal.'
+  const toolContent = JSON.stringify({
+    op: 'save',
+    pageId: selectedId,
+    title: nextTitle,
+    body: nextBody,
+    parentId: null,
+  })
+  return {
+    messages: [
+      { role: 'user', content: 'Rename this page and update the body text.' },
+      {
+        role: 'assistant',
+        content: 'Here is a proposed save. Confirm to apply.',
+        tool_calls: [
+          {
+            function: {
+              name: 'propose_page_save',
+              arguments: { page_id: selectedId },
+            },
+          },
+        ],
+      },
+      { role: 'tool', tool_name: 'propose_page_save', content: toolContent },
+    ],
+    proposal: {
+      op: 'save',
+      pageId: selectedId,
+      title: nextTitle,
+      body: nextBody,
+      parentId: null,
+    },
+  }
+}
+
+function buildDelete(selectedId: string, selectedTitle: string): E2eDemoPack {
+  const title = selectedTitle?.trim() || E2E_AGENT_DEMO_TITLE
+  const toolContent = JSON.stringify({
+    op: 'delete',
+    pageId: selectedId,
+    title,
+  })
+  return {
+    messages: [
+      { role: 'user', content: 'Delete this page.' },
+      {
+        role: 'assistant',
+        content: 'I propose deleting this page. Confirm to remove it.',
+        tool_calls: [
+          {
+            function: {
+              name: 'propose_page_delete',
+              arguments: { page_id: selectedId },
+            },
+          },
+        ],
+      },
+      { role: 'tool', tool_name: 'propose_page_delete', content: toolContent },
+    ],
+    proposal: {
+      op: 'delete',
+      pageId: selectedId,
+      title,
+    },
+  }
+}
+
+export function buildE2eAgentDemo(
+  scenario: 'create' | 'save' | 'delete',
+  selectedId: string | null,
+  selectedTitle: string,
+): E2eDemoPack | null {
+  if (scenario === 'create') {
+    return buildCreate()
+  }
+  if (scenario === 'save') {
+    return selectedId ? buildSave(selectedId) : null
+  }
+  return selectedId ? buildDelete(selectedId, selectedTitle) : null
+}

--- a/src/lib/lote-app-proposal.test.ts
+++ b/src/lib/lote-app-proposal.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatPageProposalLabel,
+  type PageProposal,
+  parsePageProposalFromTool,
+} from './lote-app.svelte'
+
+describe('parsePageProposalFromTool', () => {
+  it('parses create proposal JSON', () => {
+    const json =
+      '{"op":"create","title":"Hello","parentId":null}'
+    const p = parsePageProposalFromTool(json)
+    expect(p).toEqual({
+      op: 'create',
+      pageId: undefined,
+      title: 'Hello',
+      parentId: null,
+      body: undefined,
+    } satisfies PageProposal)
+  })
+
+  it('parses delete proposal JSON', () => {
+    const json = '{"op":"delete","pageId":"abc","title":"Note"}'
+    const p = parsePageProposalFromTool(json)
+    expect(p?.op).toBe('delete')
+    expect(p?.pageId).toBe('abc')
+  })
+
+  it('returns null for invalid payload', () => {
+    expect(parsePageProposalFromTool('not json')).toBeNull()
+    expect(parsePageProposalFromTool('{"op":"nope"}')).toBeNull()
+  })
+})
+
+describe('formatPageProposalLabel', () => {
+  it('describes each op', () => {
+    expect(
+      formatPageProposalLabel({
+        op: 'create',
+        title: 'T',
+      }),
+    ).toContain('Create')
+    expect(
+      formatPageProposalLabel({
+        op: 'save',
+        pageId: 'id-1',
+        title: 'T',
+        body: '',
+      }),
+    ).toContain('id-1')
+    expect(
+      formatPageProposalLabel({
+        op: 'delete',
+        pageId: 'x',
+        title: 'Gone',
+      }),
+    ).toContain('Gone')
+  })
+})

--- a/src/lib/lote-app.svelte.ts
+++ b/src/lib/lote-app.svelte.ts
@@ -12,11 +12,22 @@ export type AgentChatMessage = {
   tool_name?: string
 }
 
+/** Matches Rust `PageProposal` (camelCase). */
+export type PageProposal = {
+  op: 'create' | 'save' | 'delete'
+  pageId?: string
+  title?: string
+  /** Absent vs null: treat absent as undefined; empty string means root when saving. */
+  parentId?: string | null
+  body?: string
+}
+
 type AgentChatResult = {
   messages: AgentChatMessage[]
   assistantReply: string
   stepsUsed: number
   debugTrace?: string[]
+  pendingProposal?: PageProposal | null
 }
 
 export const lote = $state({
@@ -33,6 +44,8 @@ export const lote = $state({
   chatInput: '',
   chatMessages: [] as AgentChatMessage[],
   chatBusy: false,
+  /** Set when the model used a `propose_page_*` tool; cleared on confirm, dismiss, or new chat message. */
+  pendingProposal: null as PageProposal | null,
   showAgentDebug: false,
   agentDebugTrace: [] as string[],
 
@@ -59,6 +72,43 @@ export async function loadPages() {
     }
   } catch (e) {
     lote.err = String(e)
+  }
+}
+
+/** Parses JSON from a `propose_page_*` tool result (same shape as `PageProposal`). */
+/** Short label for the confirmation banner (English, user-facing). */
+export function formatPageProposalLabel(p: PageProposal): string {
+  if (p.op === 'create') {
+    return `Create page "${(p.title ?? 'Untitled').trim() || 'Untitled'}"`
+  }
+  if (p.op === 'save') {
+    return `Update page ${p.pageId ?? '(unknown id)'}`
+  }
+  return `Delete "${(p.title ?? p.pageId ?? 'page').trim() || 'page'}"`
+}
+
+export function parsePageProposalFromTool(content: string | undefined): PageProposal | null {
+  if (!content?.trim()) return null
+  try {
+    const v = JSON.parse(content) as Record<string, unknown>
+    if (!v || typeof v !== 'object') return null
+    const op = v.op
+    if (op !== 'create' && op !== 'save' && op !== 'delete') return null
+    const parentId = v.parentId
+    let normalizedParent: string | null | undefined
+    if (parentId === undefined) normalizedParent = undefined
+    else if (parentId === null) normalizedParent = null
+    else if (typeof parentId === 'string') normalizedParent = parentId
+    else return null
+    return {
+      op,
+      pageId: typeof v.pageId === 'string' ? v.pageId : undefined,
+      title: typeof v.title === 'string' ? v.title : undefined,
+      parentId: normalizedParent,
+      body: typeof v.body === 'string' ? v.body : undefined,
+    }
+  } catch {
+    return null
   }
 }
 
@@ -168,11 +218,77 @@ export async function deletePage() {
   }
 }
 
+export function dismissPendingProposal() {
+  lote.pendingProposal = null
+}
+
+export async function confirmPendingProposal() {
+  const p = lote.pendingProposal
+  if (!p || lote.chatBusy) return
+  lote.chatBusy = true
+  lote.err = ''
+  try {
+    if (p.op === 'create') {
+      const meta = await invoke<PageMeta>('pages_create', {
+        title: p.title?.trim() || 'Untitled',
+        parentId: p.parentId && p.parentId !== '' ? p.parentId : null,
+      })
+      lote.pendingProposal = null
+      await loadPages()
+      await openPage(meta.id)
+      return
+    }
+    if (p.op === 'save') {
+      const id = p.pageId
+      if (!id) {
+        lote.err = 'Proposal is missing page id'
+        return
+      }
+      await invoke('pages_save', {
+        id,
+        title: p.title ?? '',
+        parentId: p.parentId && p.parentId !== '' ? p.parentId : null,
+        body: p.body ?? '',
+      })
+      lote.pendingProposal = null
+      await loadPages()
+      if (lote.selectedId === id) {
+        const d = await invoke<PageDetail>('pages_get', { id })
+        lote.title = d.meta.title
+        lote.body = d.body
+        lote.parentSelect = d.meta.parent_id ?? ''
+      }
+      return
+    }
+    if (p.op === 'delete') {
+      const id = p.pageId
+      if (!id) {
+        lote.err = 'Proposal is missing page id'
+        return
+      }
+      await invoke('pages_delete', { id })
+      lote.pendingProposal = null
+      if (lote.selectedId === id) {
+        lote.selectedId = null
+        lote.title = ''
+        lote.body = ''
+        lote.parentSelect = ''
+      }
+      await loadPages()
+    }
+  } catch (e) {
+    lote.err = String(e)
+  } finally {
+    lote.chatBusy = false
+  }
+}
+
 export async function sendChat() {
   const msg = lote.chatInput.trim()
   if (!msg || lote.chatBusy) return
   lote.chatBusy = true
   lote.err = ''
+  lote.pendingProposal = null
   const messages: AgentChatMessage[] = [...lote.chatMessages, { role: 'user', content: msg }]
   lote.chatMessages = messages
   lote.chatInput = ''
@@ -184,6 +300,9 @@ export async function sendChat() {
     })
     lote.chatMessages = (result.messages ?? []).filter((m) => m.role !== 'system')
     lote.agentDebugTrace = result.debugTrace ?? []
+    const pending = result.pendingProposal
+    lote.pendingProposal =
+      pending && typeof pending === 'object' && 'op' in pending ? pending : null
   } catch (e) {
     lote.err = String(e)
     lote.agentDebugTrace = []

--- a/src/lib/lote-app.svelte.ts
+++ b/src/lib/lote-app.svelte.ts
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { goto } from '$app/navigation'
 import { resolve } from '$app/paths'
 import { buildE2eAgentDemo } from '$lib/lote-app-e2e-seed'
+import type { ProposalPreview } from '$lib/proposal-preview'
 import type { PageDetail, PageMeta, SearchHit } from '$lib/types'
 
 /** Matches Rust `ChatMessage` / Ollama JSON (snake_case fields). */
@@ -47,6 +48,8 @@ export const lote = $state({
   chatBusy: false,
   /** Set when the model used a `propose_page_*` tool; cleared on confirm, dismiss, or new chat message. */
   pendingProposal: null as PageProposal | null,
+  /** Human-readable before/after for the approval card (not sent to the model). */
+  pendingProposalPreview: null as ProposalPreview | null,
   showAgentDebug: false,
   agentDebugTrace: [] as string[],
 
@@ -218,11 +221,83 @@ export async function deletePage() {
   }
 }
 
+function parentFolderLabel(pages: PageMeta[], parentId: string | null | undefined): string {
+  if (parentId === null || parentId === undefined || parentId === '') {
+    return 'Root'
+  }
+  const p = pages.find((x) => x.id === parentId)
+  return p?.title?.trim() || 'Folder'
+}
+
+/**
+ * Fills {@link lote.pendingProposalPreview} from current pages + disk so the UI can show Before/After without raw ids.
+ */
+export async function refreshProposalPreview(): Promise<void> {
+  const p = lote.pendingProposal
+  if (!p) {
+    lote.pendingProposalPreview = null
+    return
+  }
+  await loadPages()
+  const pages = lote.pages
+
+  if (p.op === 'create') {
+    lote.pendingProposalPreview = {
+      kind: 'create',
+      beforeSummary: 'No page yet',
+      afterTitle: (p.title ?? 'Untitled').trim() || 'Untitled',
+      afterParentLabel: parentFolderLabel(pages, p.parentId),
+    }
+    return
+  }
+
+  if (p.op === 'delete') {
+    let pageTitle = p.title?.trim()
+    if (!pageTitle && p.pageId) {
+      try {
+        const d = await invoke<PageDetail>('pages_get', { id: p.pageId })
+        pageTitle = d.meta.title
+      } catch {
+        pageTitle = undefined
+      }
+    }
+    lote.pendingProposalPreview = {
+      kind: 'delete',
+      pageTitle: pageTitle?.trim() || 'This page',
+    }
+    return
+  }
+
+  if (p.op === 'save' && p.pageId) {
+    try {
+      const d = await invoke<PageDetail>('pages_get', { id: p.pageId })
+      lote.pendingProposalPreview = {
+        kind: 'save',
+        before: {
+          title: d.meta.title,
+          body: d.body,
+          parentLabel: parentFolderLabel(pages, d.meta.parent_id),
+        },
+        after: {
+          title: p.title ?? '',
+          body: p.body ?? '',
+          parentLabel: parentFolderLabel(pages, p.parentId),
+        },
+      }
+    } catch {
+      lote.pendingProposalPreview = null
+    }
+    return
+  }
+
+  lote.pendingProposalPreview = null
+}
+
 /**
  * Populates chat + pending proposal to mimic an agent turn (desktop capture / PR screenshots only).
  * No-op unless the app was built with `VITE_E2E_CAPTURE=true`.
  */
-export function seedE2eAgentProposalDemo(scenario: 'create' | 'save' | 'delete'): void {
+export async function seedE2eAgentProposalDemo(scenario: 'create' | 'save' | 'delete'): Promise<void> {
   if (import.meta.env.VITE_E2E_CAPTURE !== 'true') {
     return
   }
@@ -230,14 +305,17 @@ export function seedE2eAgentProposalDemo(scenario: 'create' | 'save' | 'delete')
   const pack = buildE2eAgentDemo(scenario, lote.selectedId, lote.title)
   if (!pack) {
     lote.pendingProposal = null
+    lote.pendingProposalPreview = null
     return
   }
   lote.chatMessages = pack.messages as AgentChatMessage[]
-  lote.pendingProposal = pack.proposal
+  lote.pendingProposal = pack.proposal as PageProposal
+  await refreshProposalPreview()
 }
 
 export function dismissPendingProposal() {
   lote.pendingProposal = null
+  lote.pendingProposalPreview = null
 }
 
 export async function confirmPendingProposal() {
@@ -252,6 +330,7 @@ export async function confirmPendingProposal() {
         parentId: p.parentId && p.parentId !== '' ? p.parentId : null,
       })
       lote.pendingProposal = null
+      lote.pendingProposalPreview = null
       await loadPages()
       await openPage(meta.id)
       return
@@ -269,6 +348,7 @@ export async function confirmPendingProposal() {
         body: p.body ?? '',
       })
       lote.pendingProposal = null
+      lote.pendingProposalPreview = null
       await loadPages()
       if (lote.selectedId === id) {
         const d = await invoke<PageDetail>('pages_get', { id })
@@ -286,6 +366,7 @@ export async function confirmPendingProposal() {
       }
       await invoke('pages_delete', { id })
       lote.pendingProposal = null
+      lote.pendingProposalPreview = null
       if (lote.selectedId === id) {
         lote.selectedId = null
         lote.title = ''
@@ -307,6 +388,7 @@ export async function sendChat() {
   lote.chatBusy = true
   lote.err = ''
   lote.pendingProposal = null
+  lote.pendingProposalPreview = null
   const messages: AgentChatMessage[] = [...lote.chatMessages, { role: 'user', content: msg }]
   lote.chatMessages = messages
   lote.chatInput = ''
@@ -321,9 +403,11 @@ export async function sendChat() {
     const pending = result.pendingProposal
     lote.pendingProposal =
       pending && typeof pending === 'object' && 'op' in pending ? pending : null
+    await refreshProposalPreview()
   } catch (e) {
     lote.err = String(e)
     lote.agentDebugTrace = []
+    lote.pendingProposalPreview = null
   } finally {
     lote.chatBusy = false
   }

--- a/src/lib/lote-app.svelte.ts
+++ b/src/lib/lote-app.svelte.ts
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api/core'
 
 import { goto } from '$app/navigation'
 import { resolve } from '$app/paths'
+import { buildE2eAgentDemo } from '$lib/lote-app-e2e-seed'
 import type { PageDetail, PageMeta, SearchHit } from '$lib/types'
 
 /** Matches Rust `ChatMessage` / Ollama JSON (snake_case fields). */
@@ -75,7 +76,6 @@ export async function loadPages() {
   }
 }
 
-/** Parses JSON from a `propose_page_*` tool result (same shape as `PageProposal`). */
 /** Short label for the confirmation banner (English, user-facing). */
 export function formatPageProposalLabel(p: PageProposal): string {
   if (p.op === 'create') {
@@ -216,6 +216,24 @@ export async function deletePage() {
   } catch (e) {
     lote.err = String(e)
   }
+}
+
+/**
+ * Populates chat + pending proposal to mimic an agent turn (desktop capture / PR screenshots only).
+ * No-op unless the app was built with `VITE_E2E_CAPTURE=true`.
+ */
+export function seedE2eAgentProposalDemo(scenario: 'create' | 'save' | 'delete'): void {
+  if (import.meta.env.VITE_E2E_CAPTURE !== 'true') {
+    return
+  }
+  lote.chatBusy = false
+  const pack = buildE2eAgentDemo(scenario, lote.selectedId, lote.title)
+  if (!pack) {
+    lote.pendingProposal = null
+    return
+  }
+  lote.chatMessages = pack.messages as AgentChatMessage[]
+  lote.pendingProposal = pack.proposal
 }
 
 export function dismissPendingProposal() {

--- a/src/lib/lote-app.svelte.ts
+++ b/src/lib/lote-app.svelte.ts
@@ -244,7 +244,6 @@ export async function refreshProposalPreview(): Promise<void> {
   if (p.op === 'create') {
     lote.pendingProposalPreview = {
       kind: 'create',
-      beforeSummary: 'No page yet',
       afterTitle: (p.title ?? 'Untitled').trim() || 'Untitled',
       afterParentLabel: parentFolderLabel(pages, p.parentId),
     }

--- a/src/lib/proposal-preview.test.ts
+++ b/src/lib/proposal-preview.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { compareBodyLines } from './proposal-preview'
+
+describe('compareBodyLines', () => {
+  it('marks differing lines', () => {
+    const rows = compareBodyLines('a\nb', 'a\nc')
+    expect(rows[0].unchanged).toBe(true)
+    expect(rows[1].unchanged).toBe(false)
+  })
+})

--- a/src/lib/proposal-preview.test.ts
+++ b/src/lib/proposal-preview.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
-import { compareBodyLines } from './proposal-preview'
+import { diffBodyToRows } from './proposal-preview'
 
-describe('compareBodyLines', () => {
-  it('marks differing lines', () => {
-    const rows = compareBodyLines('a\nb', 'a\nc')
-    expect(rows[0].unchanged).toBe(true)
-    expect(rows[1].unchanged).toBe(false)
+describe('diffBodyToRows', () => {
+  it('marks added and removed lines', () => {
+    const rows = diffBodyToRows('a\nb', 'a\nc')
+    const types = rows.map((r) => r.type)
+    expect(types).toContain('unchanged')
+    expect(types).toContain('remove')
+    expect(types).toContain('add')
+  })
+
+  it('handles empty before', () => {
+    const rows = diffBodyToRows('', 'only after')
+    expect(rows.some((r) => r.type === 'add')).toBe(true)
   })
 })

--- a/src/lib/proposal-preview.test.ts
+++ b/src/lib/proposal-preview.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { diffBodyToGutterRows, diffBodyToRows } from './proposal-preview'
+import { diffBodyToRows } from './proposal-preview'
 
 describe('diffBodyToRows', () => {
   it('marks added and removed lines', () => {
@@ -14,24 +14,5 @@ describe('diffBodyToRows', () => {
   it('handles empty before', () => {
     const rows = diffBodyToRows('', 'only after')
     expect(rows.some((r) => r.type === 'add')).toBe(true)
-  })
-})
-
-describe('diffBodyToGutterRows', () => {
-  it('assigns old/new line numbers like a unified diff', () => {
-    const rows = diffBodyToGutterRows('a\nb', 'a\nc')
-    expect(rows.map((r) => [r.type, r.oldLine, r.newLine])).toEqual([
-      ['unchanged', 1, 1],
-      ['remove', 2, null],
-      ['add', null, 2],
-    ])
-  })
-
-  it('numbers only-new lines from 1 upward', () => {
-    const rows = diffBodyToGutterRows('', 'x\ny')
-    expect(rows.map((r) => [r.oldLine, r.newLine])).toEqual([
-      [null, 1],
-      [null, 2],
-    ])
   })
 })

--- a/src/lib/proposal-preview.test.ts
+++ b/src/lib/proposal-preview.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { diffBodyToRows } from './proposal-preview'
+import { diffBodyToGutterRows, diffBodyToRows } from './proposal-preview'
 
 describe('diffBodyToRows', () => {
   it('marks added and removed lines', () => {
@@ -14,5 +14,24 @@ describe('diffBodyToRows', () => {
   it('handles empty before', () => {
     const rows = diffBodyToRows('', 'only after')
     expect(rows.some((r) => r.type === 'add')).toBe(true)
+  })
+})
+
+describe('diffBodyToGutterRows', () => {
+  it('assigns old/new line numbers like a unified diff', () => {
+    const rows = diffBodyToGutterRows('a\nb', 'a\nc')
+    expect(rows.map((r) => [r.type, r.oldLine, r.newLine])).toEqual([
+      ['unchanged', 1, 1],
+      ['remove', 2, null],
+      ['add', null, 2],
+    ])
+  })
+
+  it('numbers only-new lines from 1 upward', () => {
+    const rows = diffBodyToGutterRows('', 'x\ny')
+    expect(rows.map((r) => [r.oldLine, r.newLine])).toEqual([
+      [null, 1],
+      [null, 2],
+    ])
   })
 })

--- a/src/lib/proposal-preview.test.ts
+++ b/src/lib/proposal-preview.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { diffBodyToRows } from './proposal-preview'
+import {
+  collapseLongUnchangedRuns,
+  diffBodyToProposalRows,
+  diffBodyToRows,
+} from './proposal-preview'
 
 describe('diffBodyToRows', () => {
   it('marks added and removed lines', () => {
@@ -14,5 +18,37 @@ describe('diffBodyToRows', () => {
   it('handles empty before', () => {
     const rows = diffBodyToRows('', 'only after')
     expect(rows.some((r) => r.type === 'add')).toBe(true)
+  })
+})
+
+describe('collapseLongUnchangedRuns', () => {
+  it('collapses runs of 10+ unchanged lines into one row', () => {
+    const rows = Array.from({ length: 12 }, (_, i) => ({
+      type: 'unchanged' as const,
+      text: `x${i}`,
+    }))
+    const collapsed = collapseLongUnchangedRuns(rows, 10)
+    expect(collapsed).toHaveLength(1)
+    expect(collapsed[0].type).toBe('collapsed')
+    if (collapsed[0].type === 'collapsed') {
+      expect(collapsed[0].omittedCount).toBe(12)
+    }
+  })
+
+  it('does not collapse fewer than 10 unchanged lines', () => {
+    const rows = Array.from({ length: 9 }, (_, i) => ({
+      type: 'unchanged' as const,
+      text: `x${i}`,
+    }))
+    expect(collapseLongUnchangedRuns(rows, 10)).toHaveLength(9)
+  })
+})
+
+describe('diffBodyToProposalRows', () => {
+  it('collapses a long middle unchanged section', () => {
+    const before = ['a', ...Array.from({ length: 15 }, () => 'mid'), 'z'].join('\n')
+    const after = ['b', ...Array.from({ length: 15 }, () => 'mid'), 'z'].join('\n')
+    const rows = diffBodyToProposalRows(before, after)
+    expect(rows.some((r) => r.type === 'collapsed')).toBe(true)
   })
 })

--- a/src/lib/proposal-preview.ts
+++ b/src/lib/proposal-preview.ts
@@ -2,11 +2,11 @@
  * UI-only preview for pending AI page proposals (before/after copy, not persisted).
  */
 
+import { diffLines } from 'diff'
+
 export type ProposalPreview =
   | {
       kind: 'create'
-      /** Short human label for the “before” column */
-      beforeSummary: string
       afterTitle: string
       afterParentLabel: string
     }
@@ -20,30 +20,38 @@ export type ProposalPreview =
       pageTitle: string
     }
 
-/** One row of body line comparison for save proposals. */
-export type BodyLineCompareRow = {
-  beforeLine: string
-  afterLine: string
-  /** Same text on both sides — no highlight */
-  unchanged: boolean
+/** One line in a git-style body diff (unchanged lines use neutral styling). */
+export type BodyDiffRow = {
+  type: 'unchanged' | 'add' | 'remove'
+  text: string
 }
 
 /**
- * Line-aligned comparison: differing lines get Before highlighted (red) and After (green) in the UI.
+ * Line-level diff for body text: removed lines → red, added → green, unchanged → neutral.
  */
-export function compareBodyLines(before: string, after: string): BodyLineCompareRow[] {
-  const a = before.split('\n')
-  const b = after.split('\n')
-  const n = Math.max(a.length, b.length)
-  const rows: BodyLineCompareRow[] = []
-  for (let i = 0; i < n; i++) {
-    const beforeLine = i < a.length ? a[i] : ''
-    const afterLine = i < b.length ? b[i] : ''
-    rows.push({
-      beforeLine,
-      afterLine,
-      unchanged: beforeLine === afterLine,
-    })
+export function diffBodyToRows(before: string, after: string): BodyDiffRow[] {
+  const parts = diffLines(before ?? '', after ?? '')
+  const rows: BodyDiffRow[] = []
+
+  for (const part of parts) {
+    const value = part.value
+    const lines =
+      value === ''
+        ? ['']
+        : value.endsWith('\n')
+          ? value.slice(0, -1).split('\n')
+          : value.split('\n')
+
+    for (const line of lines) {
+      if (part.added) {
+        rows.push({ type: 'add', text: line })
+      } else if (part.removed) {
+        rows.push({ type: 'remove', text: line })
+      } else {
+        rows.push({ type: 'unchanged', text: line })
+      }
+    }
   }
+
   return rows
 }

--- a/src/lib/proposal-preview.ts
+++ b/src/lib/proposal-preview.ts
@@ -22,9 +22,13 @@ export type ProposalPreview =
 
 /** One line in a git-style body diff (unchanged lines use neutral styling). */
 export type BodyDiffRow = {
-  type: 'unchanged' | 'add' | 'remove'
+  type: 'unchanged' | 'add' | 'remove' | 'collapsed'
   text: string
+  /** Set when {@link type} is `collapsed`: number of unchanged lines folded into this row. */
+  omittedCount?: number
 }
+
+const DEFAULT_COLLAPSE_THRESHOLD = 10
 
 /**
  * Line-level diff for body text: removed lines → red, added → green, unchanged → neutral.
@@ -54,4 +58,57 @@ export function diffBodyToRows(before: string, after: string): BodyDiffRow[] {
   }
 
   return rows
+}
+
+/**
+ * Replaces each run of {@code threshold} or more consecutive unchanged lines with a single
+ * {@link BodyDiffRow} of type `collapsed` (for compact proposal previews).
+ */
+export function collapseLongUnchangedRuns(
+  rows: BodyDiffRow[],
+  threshold: number = DEFAULT_COLLAPSE_THRESHOLD,
+): BodyDiffRow[] {
+  if (threshold < 2) {
+    return rows
+  }
+
+  const out: BodyDiffRow[] = []
+  let i = 0
+
+  while (i < rows.length) {
+    const row = rows[i]
+    if (row.type !== 'unchanged') {
+      out.push(row)
+      i += 1
+      continue
+    }
+
+    const start = i
+    while (i < rows.length && rows[i].type === 'unchanged') {
+      i += 1
+    }
+    const runLen = i - start
+    if (runLen >= threshold) {
+      out.push({
+        type: 'collapsed',
+        text: '',
+        omittedCount: runLen,
+      })
+    } else {
+      out.push(...rows.slice(start, i))
+    }
+  }
+
+  return out
+}
+
+/**
+ * Body diff rows for the proposal UI: line diff, then collapse long unchanged runs.
+ */
+export function diffBodyToProposalRows(
+  before: string,
+  after: string,
+  collapseThreshold: number = DEFAULT_COLLAPSE_THRESHOLD,
+): BodyDiffRow[] {
+  return collapseLongUnchangedRuns(diffBodyToRows(before, after), collapseThreshold)
 }

--- a/src/lib/proposal-preview.ts
+++ b/src/lib/proposal-preview.ts
@@ -26,6 +26,14 @@ export type BodyDiffRow = {
   text: string
 }
 
+/** Same as {@link BodyDiffRow} plus unified-diff line numbers (GitHub-style gutters). */
+export type BodyDiffGutterRow = BodyDiffRow & {
+  /** Line index in the old file; null on pure additions. */
+  oldLine: number | null
+  /** Line index in the new file; null on pure removals. */
+  newLine: number | null
+}
+
 /**
  * Line-level diff for body text: removed lines → red, added → green, unchanged → neutral.
  */
@@ -54,4 +62,30 @@ export function diffBodyToRows(before: string, after: string): BodyDiffRow[] {
   }
 
   return rows
+}
+
+/**
+ * Unified diff rows with old/new line numbers for a two-column gutter (like GitHub PRs).
+ */
+export function diffBodyToGutterRows(before: string, after: string): BodyDiffGutterRow[] {
+  const base = diffBodyToRows(before, after)
+  let oldN = 0
+  let newN = 0
+  const out: BodyDiffGutterRow[] = []
+
+  for (const row of base) {
+    if (row.type === 'remove') {
+      oldN += 1
+      out.push({ ...row, oldLine: oldN, newLine: null })
+    } else if (row.type === 'add') {
+      newN += 1
+      out.push({ ...row, oldLine: null, newLine: newN })
+    } else {
+      oldN += 1
+      newN += 1
+      out.push({ ...row, oldLine: oldN, newLine: newN })
+    }
+  }
+
+  return out
 }

--- a/src/lib/proposal-preview.ts
+++ b/src/lib/proposal-preview.ts
@@ -1,0 +1,49 @@
+/**
+ * UI-only preview for pending AI page proposals (before/after copy, not persisted).
+ */
+
+export type ProposalPreview =
+  | {
+      kind: 'create'
+      /** Short human label for the “before” column */
+      beforeSummary: string
+      afterTitle: string
+      afterParentLabel: string
+    }
+  | {
+      kind: 'save'
+      before: { title: string; body: string; parentLabel: string }
+      after: { title: string; body: string; parentLabel: string }
+    }
+  | {
+      kind: 'delete'
+      pageTitle: string
+    }
+
+/** One row of body line comparison for save proposals. */
+export type BodyLineCompareRow = {
+  beforeLine: string
+  afterLine: string
+  /** Same text on both sides — no highlight */
+  unchanged: boolean
+}
+
+/**
+ * Line-aligned comparison: differing lines get Before highlighted (red) and After (green) in the UI.
+ */
+export function compareBodyLines(before: string, after: string): BodyLineCompareRow[] {
+  const a = before.split('\n')
+  const b = after.split('\n')
+  const n = Math.max(a.length, b.length)
+  const rows: BodyLineCompareRow[] = []
+  for (let i = 0; i < n; i++) {
+    const beforeLine = i < a.length ? a[i] : ''
+    const afterLine = i < b.length ? b[i] : ''
+    rows.push({
+      beforeLine,
+      afterLine,
+      unchanged: beforeLine === afterLine,
+    })
+  }
+  return rows
+}

--- a/src/lib/proposal-preview.ts
+++ b/src/lib/proposal-preview.ts
@@ -26,14 +26,6 @@ export type BodyDiffRow = {
   text: string
 }
 
-/** Same as {@link BodyDiffRow} plus unified-diff line numbers (GitHub-style gutters). */
-export type BodyDiffGutterRow = BodyDiffRow & {
-  /** Line index in the old file; null on pure additions. */
-  oldLine: number | null
-  /** Line index in the new file; null on pure removals. */
-  newLine: number | null
-}
-
 /**
  * Line-level diff for body text: removed lines → red, added → green, unchanged → neutral.
  */
@@ -62,30 +54,4 @@ export function diffBodyToRows(before: string, after: string): BodyDiffRow[] {
   }
 
   return rows
-}
-
-/**
- * Unified diff rows with old/new line numbers for a two-column gutter (like GitHub PRs).
- */
-export function diffBodyToGutterRows(before: string, after: string): BodyDiffGutterRow[] {
-  const base = diffBodyToRows(before, after)
-  let oldN = 0
-  let newN = 0
-  const out: BodyDiffGutterRow[] = []
-
-  for (const row of base) {
-    if (row.type === 'remove') {
-      oldN += 1
-      out.push({ ...row, oldLine: oldN, newLine: null })
-    } else if (row.type === 'add') {
-      newN += 1
-      out.push({ ...row, oldLine: null, newLine: newN })
-    } else {
-      oldN += 1
-      newN += 1
-      out.push({ ...row, oldLine: oldN, newLine: newN })
-    }
-  }
-
-  return out
 }

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -6,12 +6,10 @@
   import {
     confirmPendingProposal,
     dismissPendingProposal,
-    formatPageProposalLabel,
     loadPages,
     lote,
     newPage,
     openPage,
-    parsePageProposalFromTool,
     parseSearchHitsFromTool,
     runPageSearch,
     seedE2eAgentProposalDemo,
@@ -21,6 +19,7 @@
 
   import ActionButton from '../../components/action-button'
   import AppHeader from '../../components/app-header'
+  import ChatProposalApproval from '../../components/chat-proposal-approval/chat-proposal-approval.svelte'
   import ErrorBanner from '../../components/error-banner'
   import JsonPre from '../../components/json-pre'
   import PanelTitle from '../../components/panel-title'
@@ -159,21 +158,11 @@
           />
         {/if}
         <div class="min-h-0 flex-1 overflow-y-auto rounded-md border border-zinc-200 bg-white p-2 text-xs">
-          {#each lote.chatMessages.filter((m) => m.role !== 'system') as m, i (i)}
+          {#each lote.chatMessages.filter((m) => m.role !== 'system' && !(m.role === 'tool' && String(m.tool_name ?? '').startsWith('propose_page_'))) as m, i (i)}
             {#if m.role === 'user'}
               <div class="mb-2 text-zinc-800">
                 <span class="font-semibold">You:</span>
                 {m.content ?? ''}
-              </div>
-            {:else if m.role === 'tool' && m.tool_name && String(m.tool_name).startsWith('propose_page_')}
-              {@const prop = parsePageProposalFromTool(m.content)}
-              <div class="mb-2 rounded-md border border-amber-300/80 bg-amber-50/90 p-2 text-amber-950">
-                <span class="font-semibold">Proposed ({m.tool_name}):</span>
-                {#if prop}
-                  <p class="mt-1 text-[11px] leading-snug">{formatPageProposalLabel(prop)}</p>
-                {:else}
-                  <pre class="mt-1 max-h-24 overflow-auto whitespace-pre-wrap break-words font-mono text-[10px]">{m.content ?? ''}</pre>
-                {/if}
               </div>
             {:else if m.role === 'tool' && m.tool_name === 'search_pages'}
               {@const toolHits = parseSearchHitsFromTool(m.content)}
@@ -213,49 +202,25 @@
               <div class="mb-2 text-emerald-800">
                 <span class="font-semibold">Model:</span>
                 {m.content ?? ''}
-                {#if m.tool_calls?.length}
-                  <span class="text-zinc-500">
-                    [tools:
-                    {m.tool_calls.map((t) => t.function?.name ?? '?').join(', ')}]
-                  </span>
-                {/if}
               </div>
             {/if}
           {/each}
+          {#if lote.pendingProposal && lote.pendingProposalPreview}
+            <ChatProposalApproval
+              preview={lote.pendingProposalPreview}
+              busy={lote.chatBusy}
+              onApprove={() => void confirmPendingProposal()}
+              onCancel={() => dismissPendingProposal()}
+            />
+          {:else if lote.pendingProposal}
+            <div class="mb-2 rounded-md border border-amber-200 bg-amber-50/80 p-2 text-[10px] text-amber-950">
+              Loading preview…
+            </div>
+          {/if}
           {#if lote.chatBusy}
             <TypingDots />
           {/if}
         </div>
-        {#if lote.pendingProposal}
-          <div
-            class="mt-2 rounded-md border border-zinc-300 bg-white p-2 shadow-sm"
-            role="region"
-            aria-label="Confirm proposed page change"
-          >
-            <p class="text-[11px] font-medium text-zinc-800">
-              {formatPageProposalLabel(lote.pendingProposal)}
-            </p>
-            <p class="mt-1 text-[10px] text-zinc-500">
-              This action runs only if you confirm. Cancel leaves your notes unchanged.
-            </p>
-            <div class="mt-2 flex justify-end gap-1">
-              <ActionButton
-                dataTestId="chat-proposal-cancel"
-                disabled={lote.chatBusy}
-                onclick={() => dismissPendingProposal()}
-              >
-                Cancel
-              </ActionButton>
-              <ActionButton
-                dataTestId="chat-proposal-confirm"
-                disabled={lote.chatBusy}
-                onclick={() => void confirmPendingProposal()}
-              >
-                Confirm
-              </ActionButton>
-            </div>
-          </div>
-        {/if}
         <div class="mt-2 flex gap-1">
           <TextField
             class="min-w-0 flex-1 text-xs"

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -14,6 +14,7 @@
     parsePageProposalFromTool,
     parseSearchHitsFromTool,
     runPageSearch,
+    seedE2eAgentProposalDemo,
     sendChat,
   } from '$lib/lote-app.svelte'
   import * as pageTree from '$lib/pages-helpers'
@@ -33,6 +34,12 @@
 
   $effect(() => {
     void loadPages()
+  })
+
+  $effect(() => {
+    if (import.meta.env.VITE_E2E_CAPTURE === 'true') {
+      globalThis.__loteSeedAgentDemo = seedE2eAgentProposalDemo
+    }
   })
 </script>
 
@@ -232,10 +239,15 @@
               This action runs only if you confirm. Cancel leaves your notes unchanged.
             </p>
             <div class="mt-2 flex justify-end gap-1">
-              <ActionButton disabled={lote.chatBusy} onclick={() => dismissPendingProposal()}>
+              <ActionButton
+                dataTestId="chat-proposal-cancel"
+                disabled={lote.chatBusy}
+                onclick={() => dismissPendingProposal()}
+              >
                 Cancel
               </ActionButton>
               <ActionButton
+                dataTestId="chat-proposal-confirm"
                 disabled={lote.chatBusy}
                 onclick={() => void confirmPendingProposal()}
               >
@@ -247,12 +259,15 @@
         <div class="mt-2 flex gap-1">
           <TextField
             class="min-w-0 flex-1 text-xs"
+            dataTestId="chat-input"
             placeholder="Message…"
             bind:value={lote.chatInput}
             onkeydown={(e) =>
               e.key === 'Enter' && !e.shiftKey && (e.preventDefault(), void sendChat())}
           />
-          <ActionButton disabled={lote.chatBusy} onclick={() => void sendChat()}>Send</ActionButton>
+          <ActionButton dataTestId="chat-send" disabled={lote.chatBusy} onclick={() => void sendChat()}>
+            Send
+          </ActionButton>
         </div>
       </section>
     </aside>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -4,10 +4,14 @@
   import { resolve } from '$app/paths'
   import { page } from '$app/state'
   import {
+    confirmPendingProposal,
+    dismissPendingProposal,
+    formatPageProposalLabel,
     loadPages,
     lote,
     newPage,
     openPage,
+    parsePageProposalFromTool,
     parseSearchHitsFromTool,
     runPageSearch,
     sendChat,
@@ -154,6 +158,16 @@
                 <span class="font-semibold">You:</span>
                 {m.content ?? ''}
               </div>
+            {:else if m.role === 'tool' && m.tool_name && String(m.tool_name).startsWith('propose_page_')}
+              {@const prop = parsePageProposalFromTool(m.content)}
+              <div class="mb-2 rounded-md border border-amber-300/80 bg-amber-50/90 p-2 text-amber-950">
+                <span class="font-semibold">Proposed ({m.tool_name}):</span>
+                {#if prop}
+                  <p class="mt-1 text-[11px] leading-snug">{formatPageProposalLabel(prop)}</p>
+                {:else}
+                  <pre class="mt-1 max-h-24 overflow-auto whitespace-pre-wrap break-words font-mono text-[10px]">{m.content ?? ''}</pre>
+                {/if}
+              </div>
             {:else if m.role === 'tool' && m.tool_name === 'search_pages'}
               {@const toolHits = parseSearchHitsFromTool(m.content)}
               <div class="mb-2 text-amber-950">
@@ -205,6 +219,31 @@
             <TypingDots />
           {/if}
         </div>
+        {#if lote.pendingProposal}
+          <div
+            class="mt-2 rounded-md border border-zinc-300 bg-white p-2 shadow-sm"
+            role="region"
+            aria-label="Confirm proposed page change"
+          >
+            <p class="text-[11px] font-medium text-zinc-800">
+              {formatPageProposalLabel(lote.pendingProposal)}
+            </p>
+            <p class="mt-1 text-[10px] text-zinc-500">
+              This action runs only if you confirm. Cancel leaves your notes unchanged.
+            </p>
+            <div class="mt-2 flex justify-end gap-1">
+              <ActionButton disabled={lote.chatBusy} onclick={() => dismissPendingProposal()}>
+                Cancel
+              </ActionButton>
+              <ActionButton
+                disabled={lote.chatBusy}
+                onclick={() => void confirmPendingProposal()}
+              >
+                Confirm
+              </ActionButton>
+            </div>
+          </div>
+        {/if}
         <div class="mt-2 flex gap-1">
           <TextField
             class="min-w-0 flex-1 text-xs"

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -27,7 +27,14 @@
       {/each}
     </select>
   </label>
-  <ActionButton variant="primary" disabled={!lote.selectedId} onclick={() => void savePage()}>Save</ActionButton>
+  <ActionButton
+    variant="primary"
+    dataTestId="editor-save"
+    disabled={!lote.selectedId}
+    onclick={() => void savePage()}
+  >
+    Save
+  </ActionButton>
   <ActionButton variant="danger" disabled={!lote.selectedId} onclick={() => void deletePage()}>Delete</ActionButton>
   {#if lote.status}
     <span class="text-xs text-zinc-500">{lote.status}</span>
@@ -36,6 +43,7 @@
 <TextArea
   plain
   class="min-h-0 flex-1 p-4 font-mono text-sm leading-relaxed text-zinc-800"
+  dataTestId="editor-body"
   placeholder="Markdown…"
   bind:value={lote.body}
 />

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,11 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** When `"true"`, enables desktop E2E seed helpers (`__loteSeedAgentDemo`). */
+  readonly VITE_E2E_CAPTURE?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary

Implements **human-in-the-loop approval** for AI-driven page create, update, and delete (fixes #19). Destructive `pages_*` commands are **not** invoked from the agent loop. The model uses new whitelist tools (`propose_page_create`, `propose_page_save`, `propose_page_delete`) that only return structured `PageProposal` JSON. The agent loop **stops after a proposal tool** (no extra model turn) and returns `pendingProposal` to the client. The chat panel shows **Confirm / Cancel**; on confirm, the existing Tauri `pages_create` / `pages_save` / `pages_delete` commands run from the frontend.

## Base branch

`main`

## Changes

- **Rust:** `PageProposal` + `AgentChatResult.pending_proposal`; three proposal `ToolHandler`s in `ToolRegistry::with_builtin_tools`; `run_agent_loop` short-circuits when any proposal tool runs; system prompt documents the protocol.
- **Frontend:** `lote.pendingProposal`, `confirmPendingProposal` / `dismissPendingProposal`, chat UI for proposal tool messages and a confirmation banner; sending a new chat message clears a stale pending proposal.
- **Tests:** Rust runner test for proposal short-circuit; Vitest tests for `parsePageProposalFromTool` / `formatPageProposalLabel`.

## How to test

1. `npm run test` (unit), `npm run lint`, `npm run check`
2. `cd src-tauri && cargo test`
3. Manual: ask the model to delete or create a page; verify the banner appears, **Cancel** leaves data unchanged, **Confirm** applies the change and refreshes the sidebar/editor.

## Screenshots / recording

Screenshots may be appended via `npm run e2e:tauri:capture:publish` after this PR is open (Tauri desktop UI change).

## Protocol (for reviewers)

**Approach (a):** Proposal tools are registered and safe (they do not call `pages_*`). The host stops the multi-step agent loop after a proposal tool so no mutation runs until the user confirms in the UI; execution uses the same Tauri commands as the rest of the app.

## Checklist

- [x] `npm run lint` passes
- [x] No secrets or env values in code or PR text
- [x] Breaking changes: none (additive `AgentChatResult` field)

<!-- pr-auto-media:begin -->
## Screenshots (auto-uploaded)

_Hosted on GitHub Gist (not in this repository): https://gist.github.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78_

### 01-app-ready.png

![01-app-ready.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/17f582c42af9ef6044a6f54a8786fdb241843cb2/01-app-ready.png)

### 02-ai-propose-create.png

![02-ai-propose-create.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/bd85c39ce5d626c6f0dda32120bbf1582348449b/02-ai-propose-create.png)

### 03-ai-after-create-page-exists.png

![03-ai-after-create-page-exists.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/d9d3f53dbf3a80d29583dda82c703190aa8441a4/03-ai-after-create-page-exists.png)

### 04-ai-propose-edit.png

![04-ai-propose-edit.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/6f3dd4eac015c5a3e9dd23716e245ff6d433afc6/04-ai-propose-edit.png)

### 05-ai-after-edit.png

![05-ai-after-edit.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/6e6a35fd44f1d46ca0139960e850fcf399503eca/05-ai-after-edit.png)

### 06-ai-propose-delete.png

![06-ai-propose-delete.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/50df49adce00be715f61e2b70bd05e18924e64c8/06-ai-propose-delete.png)

### 07-ai-after-delete.png

![07-ai-after-delete.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/99331120e135cfd541ed72d1a8e56106c8f20a7f/07-ai-after-delete.png)

### 08-shell-new-page-smoke.png

![08-shell-new-page-smoke.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/8ad9f02086ccc81b383751590a1c0055e3d7b680/08-shell-new-page-smoke.png)

### 09-shell-title-edited.png

![09-shell-title-edited.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/d41a9ee588ba13a6ab9ce55dad8d0aecd16686da/09-shell-title-edited.png)

### 10-settings.png

![10-settings.png](https://gist.githubusercontent.com/Boccochan/ded7fab8d5262de6df63da0bbb4e8e78/raw/bbbf75e694064cf879e8d2f2ee946a1380673788/10-settings.png)

<!-- pr-auto-media:end -->
